### PR TITLE
Mark processors with secret attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 messages.log
-_pycache__
+__pycache__
 *.pyc
 db.sqlite3
 .pytest_cache

--- a/penny_u_django/bot/processors/base.py
+++ b/penny_u_django/bot/processors/base.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 class Event(dict):
     """I assume a simple model for a event for now."""
     def __init__(self, *args, **kwargs):
@@ -6,6 +8,7 @@ class Event(dict):
 
 def event_filter(filter_func):
     def decorator(func):
+        @wraps(func)
         def wrapper(*args):
             event = args[0] if isinstance(args[0], Event) else args[1]  # b/c 0 arg is `self`
             if filter_func(event):
@@ -15,6 +18,7 @@ def event_filter(filter_func):
 
 
 def event_filter_factory(filter_func_maker):
+    @wraps(filter_func_maker)
     def decorator_creator(*args, **kwargs):
         filter_func = filter_func_maker(*args, **kwargs)
         return event_filter(filter_func)

--- a/penny_u_django/bot/processors/base.py
+++ b/penny_u_django/bot/processors/base.py
@@ -6,8 +6,14 @@ class Event(dict):
         super(Event, self).__init__(*args, **kwargs)
 
 
+def process_all_events(func):
+    func.event_processor = True
+    return func
+
+
 def event_filter(filter_func):
     def decorator(func):
+        func.event_processor = True
         @wraps(func)
         def wrapper(*args):
             event = args[0] if isinstance(args[0], Event) else args[1]  # b/c 0 arg is `self`
@@ -43,8 +49,8 @@ class Bot(EventProcessor):
 
 class BotModule(EventProcessor):
     def __call__(self, event):
-        member_names = [member_name for member_name in dir(self) if member_name[:1] != '_']
+        member_names = [member_name for member_name in dir(self)]
         members = [getattr(self, member_name) for member_name in member_names]
-        methods = [member for member in members if callable(member)]
+        methods = [member for member in members if hasattr(member, 'event_processor')]
         for method in methods:
             method(event)

--- a/penny_u_django/bot/tests/processors/test_base.py
+++ b/penny_u_django/bot/tests/processors/test_base.py
@@ -33,6 +33,8 @@ def test_event_filter(mocker):
     def my_func(event):
         tester(event)
 
+    assert my_func.__name__ == 'my_func'  # otherwise we're not transferring the function properties correctly
+
     my_func(Event({'call_me': False}))
     assert tester.called is False
 
@@ -49,9 +51,13 @@ def test_event_filter_factory(mocker):
             return event['color'] == color
         return filter_func
 
+    assert is_color.__name__ == 'is_color'  # otherwise we're not transferring the function properties correctly
+
     @is_color('green')
     def my_func(event):
         tester(event)
+
+    assert my_func.__name__ == 'my_func'
 
     my_func(Event({'color': 'red'}))
     assert tester.called is False

--- a/penny_u_django/bot/tests/processors/test_base.py
+++ b/penny_u_django/bot/tests/processors/test_base.py
@@ -4,6 +4,7 @@ from bot.processors.base import (
     BotModule,
     event_filter,
     event_filter_factory,
+    process_all_events,
 )
 
 
@@ -15,15 +16,36 @@ def test_Bot(mocker):
 
 
 def test_BotModule(mocker):
-    tester = mocker.Mock()
+    tester1 = mocker.Mock()
+    tester2 = mocker.Mock()
+    tester3 = mocker.Mock()
+    tester4 = mocker.Mock()
+
     class MyBotModule(BotModule):
-        def something(self, event):
-            tester(event)
+        some_var = 'make sure we don\'t try to call this'
+
+        @event_filter(lambda e: True)  # pass through all events
+        def process_events_1(self, event):
+            tester1(event)
+
+        @process_all_events
+        def process_events_2(self, event):
+            tester2(event)
+
+        def not_a_processor_3(self, event):
+            tester3(event)
+
+        def not_a_processor_4(self, event):
+            tester4(event)
 
     my_bot_module = MyBotModule()
-    my_bot_module(Event({'some': 'message'}))
+    event = {'some': 'message'}
+    my_bot_module(Event(event))
 
-    assert tester.call_args == mocker.call({'some': 'message'})
+    assert tester1.call_args == mocker.call(event)
+    assert tester2.call_args == mocker.call(event)
+    assert tester3.called == False
+    assert tester4.called == False
 
 
 def test_event_filter(mocker):


### PR DESCRIPTION
**Problem:** the current BotModule implementation sends every event to every function defined in the module. We will surely need helper functions in the module and we don't want to send events to them as if they're processors.

**Solution:** if a bot method is supposed to process messages then mark the method with a hidden `event_processor` attribute that we can use to identify them. This required a change in the processor decorator and we also needed to make a decorator that allows the processing of all methods.