### PR TITLE
sticking db.sqlite3 and messages.log in mounted_files

### DIFF
--- a/penny_u_django/bot/tests/processors/test_greeting.py
+++ b/penny_u_django/bot/tests/processors/test_greeting.py
@@ -2,7 +2,6 @@ import pytest
 
 from bot.models import User
 from bot.processors.base import Event
-import bot.processors.greeting
 from bot.processors.greeting import GreetingBotModule
 
 

--- a/penny_u_django/penny_u_django/settings.py
+++ b/penny_u_django/penny_u_django/settings.py
@@ -78,7 +78,7 @@ WSGI_APPLICATION = 'penny_u_django.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'mounted_files', 'db.sqlite3'),
     }
 }
 
@@ -133,7 +133,7 @@ LOGGING = {
         'file': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': 'messages.log',
+            'filename': os.path.join('mounted_files', 'messages.log'),
             'formatter': 'standard',
         },
     },


### PR DESCRIPTION
Works when run with:

`docker run -p 80:80 --mount type=bind,source="$(pwd)"/mounted_files,target=/usr/src/app/mounted_files -e SLACK_API_KEY=$(cat ../../slack_api_key.txt) penny_u_django`

closes #14 