### PR TITLE
add google analytics

### DIFF
--- a/penny_u_django/home/templates/home/base.html
+++ b/penny_u_django/home/templates/home/base.html
@@ -44,6 +44,15 @@
         }
     </style>
 
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-371T9B5LM2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-371T9B5LM2');
+    </script>
+
     <title>Penny Universty</title>
 </head>
 


### PR DESCRIPTION
closes https://github.com/penny-university/penny_university/issues/17

* Created a new Google Analytics account for penny.university.mod@gmail.com.
* The GA app name is `penny-university` or `Penny University`.
* The GA homepage is https://analytics.google.com/analytics/web/provision/?authuser=2#/p208904289/reports/home?params=_u..nav%3Dga1-experimental
* Followed the directions to add basic GA tagging. This will just measure traffic for now. Nothing special w/ button clicks, etc.