### PR TITLE
Do `runserver --insecure` so that we could turn off debug mode and still serve static files

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: python manage.py migrate
-web: python manage.py runserver 0.0.0.0:$PORT
+web: python manage.py runserver --insecure 0.0.0.0:$PORT

--- a/penny_university/settings.py
+++ b/penny_university/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '7e@1*$kub8yxjd&pkej#+0k+e9omlz!31$zuq(4$rglm4i(hp1'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('PENNY_DEBUG', '').lower() == "true"
+DEBUG = True  # os.environ.get('PENNY_DEBUG', '').lower() == "true"
 
 ALLOWED_HOSTS = ['*']  # TODO this is a hack - fix once we have domain name set up
 

--- a/penny_university/settings.py
+++ b/penny_university/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '7e@1*$kub8yxjd&pkej#+0k+e9omlz!31$zuq(4$rglm4i(hp1'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True  # os.environ.get('PENNY_DEBUG', '').lower() == "true"
+DEBUG = os.environ.get('PENNY_DEBUG', '').lower() == "true"
 
 ALLOWED_HOSTS = ['*']  # TODO this is a hack - fix once we have domain name set up
 


### PR DESCRIPTION
`runserver --insecure` sounds _not_ ideal but
A) it allows us to turn DEBUG off which _was_ leaking importing info
B) we can load CSS