### PR TITLE
Server static files in production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: python manage.py migrate
-web: gunicorn penny_university.wsgi
+web: gunicorn --workers=2 penny_university.wsgi

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: python manage.py migrate
-web: python manage.py runserver --insecure 0.0.0.0:$PORT
+web: python manage.py runserver 0.0.0.0:$PORT

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: python manage.py migrate
-web: python manage.py runserver 0.0.0.0:$PORT
+web: gunicorn penny_university.wsgi

--- a/penny_university/settings.py
+++ b/penny_university/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 import os
 import dj_database_url
-import django_heroku
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -160,7 +159,3 @@ SLACK_API_KEY = os.environ.get('SLACK_API_KEY')
 if SLACK_API_KEY is None:
     print('WARNING: SLACK_API_KEY is None')
 PENNY_ADMIN_USERS = ['@JB', '@nick.chouard']
-
-
-# Activate Django-Heroku. Suggested by Heroku for django configurations. Keep at the bottom of this file.
-django_heroku.settings(locals())

--- a/penny_university/settings.py
+++ b/penny_university/settings.py
@@ -12,10 +12,13 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 import os
 import dj_database_url
+import django_heroku
+
+# Activate Django-Heroku. Suggested by Heroku for django configurations
+django_heroku.settings(locals())
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
@@ -27,7 +30,6 @@ SECRET_KEY = '7e@1*$kub8yxjd&pkej#+0k+e9omlz!31$zuq(4$rglm4i(hp1'
 DEBUG = os.environ.get('PENNY_DEBUG', '').lower() == "true"
 
 ALLOWED_HOSTS = ['*']  # TODO this is a hack - fix once we have domain name set up
-
 
 # Application definition
 
@@ -44,6 +46,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -74,7 +77,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'penny_university.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
@@ -83,7 +85,6 @@ DATABASES = {}
 # in heroku the production DATABASE_URL is defined (see `heroku config`)
 # if neither is defined then we presume we're in dev and just use sqlite
 DATABASES['default'] = dj_database_url.config(default='sqlite:///db.sqlite3', conn_max_age=600)
-
 
 # Password validation
 # https://docs.djangoproject.com/en/2.1/ref/settings/#auth-password-validators
@@ -103,7 +104,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/
 
@@ -116,7 +116,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
@@ -159,7 +158,6 @@ if not DEBUG:
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
-
 
 SLACK_API_KEY = os.environ.get('SLACK_API_KEY')
 if SLACK_API_KEY is None:

--- a/penny_university/settings.py
+++ b/penny_university/settings.py
@@ -14,9 +14,6 @@ import os
 import dj_database_url
 import django_heroku
 
-# Activate Django-Heroku. Suggested by Heroku for django configurations
-django_heroku.settings(locals())
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -163,3 +160,7 @@ SLACK_API_KEY = os.environ.get('SLACK_API_KEY')
 if SLACK_API_KEY is None:
     print('WARNING: SLACK_API_KEY is None')
 PENNY_ADMIN_USERS = ['@JB', '@nick.chouard']
+
+
+# Activate Django-Heroku. Suggested by Heroku for django configurations. Keep at the bottom of this file.
+django_heroku.settings(locals())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 django>=2.1.10
+django-heroku==0.3.1
 dj-database-url==0.5.0
+gunicorn==19.9.0
 slackclient==2.0.0
 requests==2.22.0
 uwsgi==2.0.18
+whitenoise==4.1.4
 
 # I had a little trouble installing psycopg2, this finally worked
 # brew install postgres

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 django>=2.1.10
-django-heroku==0.3.1
 dj-database-url==0.5.0
 gunicorn==19.9.0
 slackclient==2.0.0


### PR DESCRIPTION
* Added Whitenoise to server static files
* Added gunicorn to serve Django app, as suggested by heroku docs https://devcenter.heroku.com/articles/django-app-configuration

Heroku automatically calls "collectstatic" which allows the files to be served in production.