### PR TITLE
Update base bot

### DIFF
--- a/bot/processors/base.py
+++ b/bot/processors/base.py
@@ -24,15 +24,15 @@ def process_all_events(func):
     return func
 
 
-def processor_decorator(transform_filter_func):
-    """Makes a processor decorator out of the function that it decorates.
+def event_processor_decorator(transform_filter_func):
+    """Makes an event processor decorator out of the function that it decorates.
 
-    A processor is a function that takes an event and does something with it. It can be any callable including instance
-    methods and class methods. The only constraint is that it should have a single input representing an event and that
-    input must be name "event". There is no constraint on what an event is at all.
+    An event processor is a function that takes an event and does something with it. It can be any callable including
+    instance methods and class methods. The only constraint is that it should have a single input representing an event
+    and that input must be name "event". There is no constraint on what an event is at all.
 
     In its most basic form, a transform_filter_func takes an event and returns True if the filter applies to that event.
-    Such a transform_filter_func decorated by processor_decorator itself _becomes_ a decorator that can modify
+    Such a transform_filter_func decorated by event_processor_decorator itself _becomes_ a decorator that can modify
     processors and filter their events. Example:
 
     ```
@@ -72,7 +72,7 @@ def processor_decorator(transform_filter_func):
         assert 'BOO' in event.text, 'this should never fail'
     ```
 
-    For more information see the `test_processor_decorator__*` tests.
+    For more information see the `test_event_processor_decorator__*` tests.
     """
 
     @wraps(transform_filter_func)
@@ -130,7 +130,7 @@ def processor_decorator(transform_filter_func):
             # so I'm now applying @wraps here - I'm just hoping `partial` does the correct thing
             # partial has a `func` attribute that points to the function that was partially applied
             new_filter_func = partial(transform_filter_func, *dec_args, **dec_kwargs)
-            return processor_decorator(new_filter_func)
+            return event_processor_decorator(new_filter_func)
 
     return decorator
 

--- a/bot/processors/filters.py
+++ b/bot/processors/filters.py
@@ -1,42 +1,33 @@
-from bot.processors.base import (
-    event_filter,
-    event_filter_factory,
-)
+from bot.processors.base import event_processor_decorator
 from common.helpers import CHANNEL_NAME__ID
 
 
-@event_filter_factory
-def in_room(room):
-    def filter_func(event):
-        return 'channel' in event and event['channel'] == CHANNEL_NAME__ID[room]
-
-    return filter_func
+@event_processor_decorator
+def in_room(room, event):
+    return 'channel' in event and event['channel'] == CHANNEL_NAME__ID[room]
 
 
-@event_filter_factory
-def is_event_type(type_string):
-    def filter_func(event):
-        type_arr = type_string.split('.')
-        assert 1 <= len(type_arr) <= 2, \
-            'Format for type_string must be "foo" or "foo.bar" of "*.bar" or "foo.*"'
-        if len(type_arr) == 1:
-            type_arr.append('*')
-        if 'type' not in event:
+@event_processor_decorator
+def is_event_type(type_string, event):
+    type_arr = type_string.split('.')
+    assert 1 <= len(type_arr) <= 2, \
+        'Format for type_string must be "foo" or "foo.bar" of "*.bar" or "foo.*"'
+    if len(type_arr) == 1:
+        type_arr.append('*')
+    if 'type' not in event:
+        return False
+    if type_arr[0] != '*' and event['type'] != type_arr[0]:
+        return False
+    if 'subtype' in event:
+        if type_arr[1] != '*' and event['subtype'] != type_arr[1]:
             return False
-        if type_arr[0] != '*' and event['type'] != type_arr[0]:
+    else:
+        if type_arr[1] != '*':
             return False
-        if 'subtype' in event:
-            if type_arr[1] != '*' and event['subtype'] != type_arr[1]:
-                return False
-        else:
-            if type_arr[1] != '*':
-                return False
-        return True
-
-    return filter_func
+    return True
 
 
-@event_filter
+@event_processor_decorator
 def is_block_interaction_event(event):
     """Detects whether or not the event is a block interaction event
 
@@ -45,20 +36,14 @@ def is_block_interaction_event(event):
     return 'trigger_id' in event
 
 
-@event_filter_factory
-def has_callback_id(callback_id):
-    def filter_func(event):
-        if 'callback_id' in event:
-            return event['callback_id'] == callback_id
-        else:
-            return event['view']['callback_id']
-
-    return filter_func
+@event_processor_decorator
+def has_callback_id(callback_id, event):
+    if 'callback_id' in event:
+        return event['callback_id'] == callback_id
+    else:
+        return event['view']['callback_id']
 
 
-@event_filter_factory
-def is_action_id(action_id):
-    def filter_func(event):
-        return 'actions' in event and event['actions'][0]['action_id'] == action_id
-
-    return filter_func
+@event_processor_decorator
+def is_action_id(action_id, event):
+    return 'actions' in event and event['actions'][0]['action_id'] == action_id

--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -132,6 +132,12 @@ def onboarding_template(user=None):
 
 
 class GreetingBotModule(BotModule):
+    processors = [
+        'welcome_user',
+        'show_interests_dialog',
+        'submit_interests',
+    ]
+
     def __init__(self, slack):
         self.slack = slack
 

--- a/bot/processors/pennychat.py
+++ b/bot/processors/pennychat.py
@@ -302,6 +302,16 @@ def penny_chat_details_modal(penny_chat):
 
 
 class PennyChatBotModule(BotModule):
+    processors = [
+        'date_select',
+        'time_select',
+        'user_select',
+        'channel_select',
+        'submit_details',
+        'edit_chat',
+        'share',
+    ]
+
     def __init__(self, slack):
         self.slack = slack
 

--- a/bot/tests/processors/test_base.py
+++ b/bot/tests/processors/test_base.py
@@ -5,7 +5,7 @@ from bot.processors.base import (
     event_filter,
     event_filter_factory,
     process_all_events,
-    processor_decorator,
+    event_processor_decorator,
 )
 
 
@@ -49,10 +49,10 @@ def test_BotModule(mocker):
     assert not tester4.called
 
 
-def test_processor_decorator__as_filter_for_function(mocker):
+def test_event_processor_decorator__as_filter_for_function(mocker):
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def contains_kitten(event):
         return 'kitten' in event
 
@@ -69,10 +69,10 @@ def test_processor_decorator__as_filter_for_function(mocker):
     assert tester.call_count == 1
 
 
-def test_processor_decorator__as_filter_for_method(mocker):
+def test_event_processor_decorator__as_filter_for_method(mocker):
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def contains_kitten(event):
         return 'kitten' in event
 
@@ -90,10 +90,10 @@ def test_processor_decorator__as_filter_for_method(mocker):
     assert tester.call_count == 1
 
 
-def test_processor_decorator__as_transformer_for_function(mocker):
+def test_event_processor_decorator__as_transformer_for_function(mocker):
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def from_bob(event):
         if event['from'] == 'bob':
             event['extra_data'] = '1234'
@@ -110,10 +110,10 @@ def test_processor_decorator__as_transformer_for_function(mocker):
     assert tester.call_count == 1
 
 
-def test_processor_decorator__as_transformer_for_method(mocker):
+def test_event_processor_decorator__as_transformer_for_method(mocker):
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def from_bob(event):
         if event['from'] == 'bob':
             event['extra_data'] = '1234'
@@ -131,10 +131,10 @@ def test_processor_decorator__as_transformer_for_method(mocker):
     assert tester.call_count == 1
 
 
-def test_processor_decorator__as_filter_maker(mocker):
+def test_event_processor_decorator__as_filter_maker(mocker):
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def from_user(user_name, event):
         return event['from'] == user_name
 
@@ -169,12 +169,12 @@ def test_processor_decorator__as_filter_maker(mocker):
     assert tester.call_count == 1
 
 
-def test_processor_decorator__nested_function(mocker):
+def test_event_processor_decorator__nested_function(mocker):
     # I'm testing this because in an earlier implementation there was a bug when nesting deeper into
-    # processor_decorators. Multiple redundant decorators should work the same as a single decorator
+    # event_processor_decorators. Multiple redundant decorators should work the same as a single decorator
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def from_bob(event):
         return event['from'] == 'bob'
 
@@ -191,12 +191,12 @@ def test_processor_decorator__nested_function(mocker):
     assert tester.call_count == 1
 
 
-def test_processor_decorator__nested_method(mocker):
-    # Ref test_processor_decorator__nested_function, there was a related, but different bug with applying nested
+def test_event_processor_decorator__nested_method(mocker):
+    # Ref test_event_processor_decorator__nested_function, there was a related, but different bug with applying nested
     # decorators to methods
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def from_bob(event):
         return event['from'] == 'bob'
 
@@ -214,10 +214,10 @@ def test_processor_decorator__nested_method(mocker):
     assert tester.call_count == 1
 
 
-def test_processor_decorator__decorating_bot_modules(mocker):
+def test_event_processor_decorator__decorating_bot_modules(mocker):
     tester = mocker.Mock()
 
-    @processor_decorator
+    @event_processor_decorator
     def from_bob(event):
         return event['from'] == 'bob'
 

--- a/bot/tests/processors/test_greeting.py
+++ b/bot/tests/processors/test_greeting.py
@@ -1,7 +1,6 @@
 import pytest
 
 from users.models import UserProfile
-from bot.processors.base import Event
 from bot.processors.greeting import GreetingBotModule
 
 
@@ -9,7 +8,7 @@ def test_greeting(mocker):
     slack = mocker.Mock()
     greeter = GreetingBotModule(slack)
     GreetingBotModule.GREETING_MESSAGE = 'welcome'
-    event = Event({
+    event = {
         'user': 'U42HCBFEF',
         'type': 'message',
         'subtype': 'channel_join',
@@ -18,7 +17,7 @@ def test_greeting(mocker):
         'channel': 'C41G02RK4',  # general
         'event_ts': '1557281569.001300',
         'channel_type': 'channel'
-    })
+    }
     with mocker.patch('bot.processors.greeting.greeting_blocks', return_value='welcome'):
         with mocker.patch('bot.processors.greeting.notify_admins'):
             greeter(event)
@@ -28,7 +27,7 @@ def test_greeting(mocker):
 def test_greeting_wrong_channel(mocker):
     slack = mocker.Mock()
     greeter = GreetingBotModule(slack)
-    event = Event({
+    event = {
         'user': 'U42HCBFEF',
         'type': 'message',
         'subtype': 'channel_join',
@@ -37,7 +36,7 @@ def test_greeting_wrong_channel(mocker):
         'channel': 'WRONGCHANNELHERE',
         'event_ts': '1557281569.001300',
         'channel_type': 'channel'
-    })
+    }
     greeter(event)
     assert not slack.chat.post_message.called
 
@@ -45,7 +44,7 @@ def test_greeting_wrong_channel(mocker):
 def test_greeting_wrong_type(mocker):
     slack = mocker.Mock()
     greeter = GreetingBotModule(slack)
-    event = Event({
+    event = {
         'user': 'U42HCBFEF',
         'type': 'message',
         'subtype': 'wrong_type',
@@ -54,7 +53,7 @@ def test_greeting_wrong_type(mocker):
         'channel': 'CHCM2MFHU',
         'event_ts': '1557281569.001300',
         'channel_type': 'channel'
-    })
+    }
     greeter(event)
     assert not slack.chat.post_message.called
 
@@ -63,7 +62,7 @@ def test_greeting_wrong_type(mocker):
 def test_show_interests_dialog(mocker):
     slack = mocker.Mock()
     bot_module = GreetingBotModule(slack)
-    event = Event({
+    event = {
         'type': 'block_actions',
         'trigger_id': 'whatevs',
         'actions': [
@@ -74,7 +73,7 @@ def test_show_interests_dialog(mocker):
         'user': {
             'id': 0
         }
-    })
+    }
 
     with mocker.patch('bot.processors.greeting.onboarding_template', return_value='welcome'):
         bot_module(event)
@@ -88,7 +87,7 @@ def test_show_interests_dialog_existing_user(mocker):
 
     UserProfile.objects.create(slack_id=0, topics_to_learn='django')
 
-    event = Event({
+    event = {
         'type': 'block_actions',
         'trigger_id': 'whatevs',
         'actions': [
@@ -99,7 +98,7 @@ def test_show_interests_dialog_existing_user(mocker):
         'user': {
             'id': 0
         }
-    })
+    }
 
     bot_module(event)
     assert slack.dialog_open.call_args[1]['dialog']['elements'][0]['name'] == 'topics_to_learn'
@@ -114,7 +113,7 @@ def test_submit_interests(mocker):
     bot_module = GreetingBotModule(slack)
 
     # Create initial response
-    event = Event({
+    event = {
         'type': 'dialog_submission',
         'callback_id': 'interests',
         'user': {'id': 'SOME_USER_ID'},
@@ -124,7 +123,7 @@ def test_submit_interests(mocker):
             'topics_to_share': '',  # user omitted answer
             'how_you_learned_about_pennyu': 'SOME_REFERER',
         }
-    })
+    }
 
     slack_resp = mocker.Mock()
     slack.users_info.return_value = slack_resp
@@ -158,7 +157,7 @@ def test_submit_interests(mocker):
     assert 'knows a thing' not in slack.chat_postMessage.call_args_list[0][1]['text']
 
     # create updated response
-    event = Event({
+    event = {
         'type': 'dialog_submission',
         'callback_id': 'interests',
         'user': {'id': 'SOME_USER_ID'},
@@ -168,7 +167,7 @@ def test_submit_interests(mocker):
             'topics_to_share': 'SOME_OTHER_TEACHINGS',
             'how_you_learned_about_pennyu': 'SOME_OTHER_REFERER',
         }
-    })
+    }
 
     bot_module(event)
 

--- a/bot/tests/processors/test_pennychat.py
+++ b/bot/tests/processors/test_pennychat.py
@@ -2,7 +2,6 @@ import pytest
 from datetime import datetime
 from pytz import timezone, utc
 
-from bot.processors.base import Event
 from bot.processors.pennychat import PennyChatBotModule
 
 from pennychat.models import PennyChat
@@ -30,7 +29,7 @@ def test_date_select(mocker):
 
     chat_id = create_penny_chat()
 
-    event = Event({
+    event = {
         'type': 'block_actions',
         'trigger_id': 'trigger',
         'view': {
@@ -45,7 +44,7 @@ def test_date_select(mocker):
         'user': {
             'id': 'user'
         }
-    })
+    }
 
     bot_module(event)
 
@@ -60,7 +59,7 @@ def test_time_select(mocker):
 
     chat_id = create_penny_chat()
 
-    event = Event({
+    event = {
         'type': 'block_actions',
         'trigger_id': 'trigger',
         'view': {
@@ -77,7 +76,7 @@ def test_time_select(mocker):
         'user': {
             'id': 'user'
         }
-    })
+    }
 
     bot_module(event)
     penny_chat = PennyChat.objects.get(id=chat_id)

--- a/bot/tests/processors/test_utils.py
+++ b/bot/tests/processors/test_utils.py
@@ -1,4 +1,3 @@
-from bot.processors.base import Event
 from bot.processors.greeting import is_event_type
 
 
@@ -48,20 +47,20 @@ def test_is_event_type():
 
     non_typed_event = {}
 
-    assert fruit_apple_handler(Event(fruit_apple_event))
-    assert star_apple_handler(Event(fruit_apple_event))
-    assert fruit_star_handler(Event(fruit_apple_event))
-    assert fruit_handler(Event(fruit_apple_event))  # unspecified subtype is same as '*'
-    assert star_star_handler(Event(fruit_apple_event))
-    assert fruit_star_handler(Event(fruit_event))
-    assert fruit_handler(Event(fruit_event))
+    assert fruit_apple_handler(fruit_apple_event)
+    assert star_apple_handler(fruit_apple_event)
+    assert fruit_star_handler(fruit_apple_event)
+    assert fruit_handler(fruit_apple_event)  # unspecified subtype is same as '*'
+    assert star_star_handler(fruit_apple_event)
+    assert fruit_star_handler(fruit_event)
+    assert fruit_handler(fruit_event)
 
-    assert not fruit_apple_handler(Event(fruit_banana_event))
-    assert not fruit_apple_handler(Event(computer_apple_event))
-    assert not star_apple_handler(Event(fruit_banana_event))
-    assert not fruit_star_handler(Event(computer_apple_event))
-    assert not fruit_star_handler(Event(computer_event))
-    assert not fruit_apple_handler(Event(fruit_event))
+    assert not fruit_apple_handler(fruit_banana_event)
+    assert not fruit_apple_handler(computer_apple_event)
+    assert not star_apple_handler(fruit_banana_event)
+    assert not fruit_star_handler(computer_apple_event)
+    assert not fruit_star_handler(computer_event)
+    assert not fruit_apple_handler(fruit_event)
 
     # if is_event_type is used, then it's assumed that event must be typed
-    assert not star_star_handler(Event(non_typed_event))
+    assert not star_star_handler(non_typed_event)

--- a/bot/views.py
+++ b/bot/views.py
@@ -10,10 +10,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 
 from bot.processors.greeting import GreetingBotModule
 from bot.processors.pennychat import PennyChatBotModule
-from bot.processors.base import (
-    Bot,
-    Event,
-)
+from bot.processors.base import Bot
 
 slack_client = slack.WebClient(token=settings.SLACK_API_KEY)
 bot = Bot(event_processors=[GreetingBotModule(slack_client), PennyChatBotModule(slack_client)])
@@ -39,7 +36,7 @@ def hook(request):
         if 'subtype' in event and event['subtype'] == 'bot_message':
             is_bot = True
         if not is_bot:
-            bot(Event(event))
+            bot(event)
         return HttpResponse('')
 
 
@@ -50,7 +47,7 @@ def interactive(request):
     message_logger = logging.getLogger('messages')
     message_logger.info(request.POST['payload'])
 
-    bot(Event(payload))
+    bot(payload)
 
     return HttpResponse('')
 


### PR DESCRIPTION
Upgraded bot. Features:
* `event_filter` and `event_filter_factory` have been replaced with a single and much simpler decorator called `event_processor_decorator`
* `BotModules` now require a `processors` array representing the list of event processors to use and the order to run them in.
* Events no longer have to subclass from `Event` - they can be absolutely anything.
* deleted `process_all_events` decorator
* fixed tests

I need a 🚢 on this, but before I merge this I _still_ need to make sure that all the pieces work in the QA slack first.

