### PR TITLE
error in penny chat is created w/ no invitees

### DIFF
--- a/bot/processors/base.py
+++ b/bot/processors/base.py
@@ -150,7 +150,7 @@ class Bot:
         self.event_processors = event_processors
 
     def __call__(self, event):
-        """Sends event to all modules and returns response to caller.
+        """Sends event to all modules and optionally returns response to caller.
 
         Errors if there is more than on response from a module.
         :param event:
@@ -184,6 +184,12 @@ class BotModule:
     ```
     """
     def __call__(self, event):
+        """Sends event to all event processors optionally returns response to caller.
+
+        Errors if there is more than on response from a event processors.
+        :param event:
+        :return:
+        """
         assert hasattr(self, 'processors') and isinstance(self.processors, list), (
             'BotModules should define `processors`, a list of the processors to run and the order to run them in.'
         )

--- a/bot/processors/base.py
+++ b/bot/processors/base.py
@@ -150,8 +150,24 @@ class Bot:
         self.event_processors = event_processors
 
     def __call__(self, event):
+        """Sends event to all modules and returns response to caller.
+
+        Errors if there is more than on response from a module.
+        :param event:
+        :return:
+        """
+        responses = []
         for event_processor in self.event_processors:
-            event_processor(event)
+            resp = event_processor(event)
+            if resp:
+                responses.append(resp)
+
+        if len(responses) > 1:
+            raise RuntimeError(
+                "Only one response allowed for Bot. More than one response is ambiguous. Which one do we send?"
+            )
+        if responses:
+            return responses[0]
 
 
 class BotModule:
@@ -171,13 +187,16 @@ class BotModule:
         assert hasattr(self, 'processors') and isinstance(self.processors, list), (
             'BotModules should define `processors`, a list of the processors to run and the order to run them in.'
         )
+        responses = []
         for processor in self.processors:
             assert hasattr(self, processor), (
                 f'Processor `{processor}` expected in BotModule {self.__class__.__module__}.{self.__class__.__name__} '
                 'but not found.'
             )
             try:
-                getattr(self, processor)(event)
+                resp = getattr(self, processor)(event)
+                if resp:
+                    responses.append(resp)
             except TypeError as e:
                 if e.args and "missing 1 required positional argument: 'event'" in e.args[0]:
                     raise TypeError(
@@ -187,3 +206,11 @@ class BotModule:
                     )
                 else:
                     raise
+
+            if len(responses) > 1:
+                raise RuntimeError(
+                    "Only one response allowed for BotModule. More than one response is ambiguous. "
+                    "Which one do we send?"
+                )
+            if responses:
+                return responses[0]

--- a/bot/processors/pennychat.py
+++ b/bot/processors/pennychat.py
@@ -373,14 +373,22 @@ class PennyChatBotModule(BotModule):
 
         penny_chat.title = state['penny_chat_title']['penny_chat_title']['value']
         penny_chat.description = state['penny_chat_description']['penny_chat_description']['value']
-
         penny_chat.save()
 
-        self.slack.chat_postEphemeral(
-            channel=penny_chat.template_channel,
-            user=penny_chat.user,
-            blocks=save_message_template(self.slack, penny_chat),
-        )
+        if len(penny_chat.invitees.strip()) == 0 and len(penny_chat.channels.strip()) == 0:
+            return {
+                "response_action": "errors",
+                "errors": {
+                    "penny_chat_description": "One is a lonely number for a Penny Chat. "
+                                              "Invite at least one channel or user below."
+                }
+            }
+        else:
+            self.slack.chat_postEphemeral(
+                channel=penny_chat.template_channel,
+                user=penny_chat.user,
+                blocks=save_message_template(self.slack, penny_chat),
+            )
 
     @is_block_interaction_event
     @is_action_id('penny_chat_edit')

--- a/bot/views.py
+++ b/bot/views.py
@@ -4,7 +4,10 @@ import logging
 from django.conf import settings
 import slack
 
-from django.http import HttpResponse
+from django.http import (
+    HttpResponse,
+    JsonResponse,
+)
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.clickjacking import xframe_options_exempt
 
@@ -43,8 +46,11 @@ def hook(request):
 def interactive(request):
     event = json.loads(request.POST['payload'])
     logging.info(f'INTERACTIVE> {request.POST["payload"]}')
-    bot(event)
-    return HttpResponse('')
+    resp = bot(event)
+    if resp:
+        return JsonResponse(resp)
+
+    return HttpResponse()
 
 
 @csrf_exempt


### PR DESCRIPTION
*Goal:* if someone creates a penny chat w/ no channels or users invited, then error and provide a message to include some invitees

*Strategy:* In order to do this we have to respond to submission with a `response_action` payload. This means transmitting the message back through the `BotModule` and the `Bot` to the original call in `interactive` view handler. At both levels I'm choosing to send the event to all sub botmodules or event_handlers and if any _one_ of them return a non-`None` response then I'll propagate that back up the the original caller. If more than one returns a response then that's ambiguous (which response do you use?) so I raise and exception.

*Problem:* Slack's API is ... difficult. For `reasons` I don't seem to be able to attach error messages to the new action family of blocks. So I can't attach an error to the empty `invitees` and `channels` blocks in questions. There's also apparently no way to make a form-wide error (e.g. the message must be attached to one of the form elements). So just to get something out, I've stuck the error on the Description./e (The Title has scrolled off the top of the page.)

![image](https://user-images.githubusercontent.com/566533/68918177-c8645800-0732-11ea-8215-a26249d40f1d.png)
