### PR TITLE
removed user from PennyChat serialization

### DIFF
--- a/pennychat/serializers.py
+++ b/pennychat/serializers.py
@@ -6,11 +6,10 @@ from users.serializers import UserProfileSerializer
 
 class PennyChatSerializer(serializers.HyperlinkedModelSerializer):
     follow_ups = serializers.HyperlinkedIdentityField(view_name='followup-list')
-    user = UserProfileSerializer(read_only=True)
 
     class Meta:
         model = PennyChat
-        fields = ['id', 'url', 'title', 'description', 'date', 'user', 'follow_ups']
+        fields = ['id', 'url', 'title', 'description', 'date', 'follow_ups']
 
 
 class FollowUpSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
We had a bug b/c the PennyChat serializer expected a PennyChat.user to be a full user model, but it was a string. Since we're moving to Participants, I chose to remove user from the serializer.