### PR TITLE
Updated import commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To cancel just visit http://yourapp.herokuapp.com/forward
 
 
 ## Pull in data from forum or slack
-* Pull chats and follow ups from Google Group by getting a dump of the data from https://takeout.google.com, unzipping it, and then running `./manage.py import_google_forum --data_dump_path <somewhere>/Takeout/Groups/penny-university\@googlegroups.com/topics.mbox  --to_database`
+* Pull chats and follow ups from Google Group by getting a dump of the data from https://takeout.google.com, unzipping it, and then running `cat /wherever/topics.mbox | ./manage.py import_google_forum --to_database`. To run it remotely against our Heroku app run `cat /wherever/topics.mbox | heroku run --no-tty -a <your-app> ./manage.py import_google_forum --to_database`.
 * Pull users from slack (most importantly their real_name) using `./manage.py import_users_from_slack`
+* As stated above, these will only run dry runs. To actually commit the data to the database, add the `--live_run` parameter.
 

--- a/pennychat/management/commands/import_google_forum.py
+++ b/pennychat/management/commands/import_google_forum.py
@@ -23,7 +23,10 @@ from users.models import UserProfile
 class Command(BaseCommand):
     help = (
         'Extract and normalize content from penny university google forum. '
-        'Requires that you retrieve forum content here: https://takeout.google.com'
+        'Requires that you retrieve forum content here: https://takeout.google.com. '
+        'Run remotely with `cat /wherever/topics.mbox | heroku run --no-tty -a <your-app> ./manage.py import_google_'
+        'forum --to_database`. When doing --live_run, if you have problems then make the --live_run argument NOT the '
+        'last argument. ¯\\_(ツ)_/¯'
     )
 
     def add_arguments(self, parser):
@@ -325,7 +328,7 @@ def import_to_database(formated_chats, live_run=False):
                 print('THIS IS A DRY RUN ONLY - NOT COMMITTING')
                 print('Run with --live_run to actually commit.')
                 raise RuntimeError('not committing')
-            print('committed')
+            print('COMMITTED')
     except Exception as e:
         if str(e) == 'not committing':
             pass

--- a/pennychat/management/commands/import_google_forum.py
+++ b/pennychat/management/commands/import_google_forum.py
@@ -3,6 +3,7 @@ from dateutil.parser import parse
 import json
 import mailbox
 import re
+import sys
 
 from django.conf import settings
 from django.core.management.base import (
@@ -27,13 +28,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--data_dump_path',
-            dest='data_dump_path',
-            action='store',
-            help='unzipped google data dump path to topics.mbox',
-            required=True,
-        )
-        parser.add_argument(
             '--output_file',
             dest='output_file',
             action='store',
@@ -47,12 +41,28 @@ class Command(BaseCommand):
             help='where to dump the output',
             required=False,
         )
+        parser.add_argument(
+            '--live_run',
+            dest='live_run',
+            action='store_true',
+            help='opposite of dry run - will actually write data to the database',
+            required=False,
+        )
 
     def handle(self, *args, **options):
+        print('Waiting to receive piped in .mbox file')
+        mbox_path = '/tmp/mbox_dump.txt'
+        with open(mbox_path, 'w') as f:
+            charcount = f.write(sys.stdin.read())
+
+        if charcount == 0:
+            raise RuntimeError('Unable to write .mbox to file')
+        else:
+            print('Wrote .mbox file to disk')
+
         if not options['to_database'] and not options['output_file']:
             raise CommandError('Either `to_database` or `output_file` must be specified.')
 
-        mbox_path = options['data_dump_path']
         mbox = mailbox.mbox(mbox_path)
         messages = get_messages(mbox)
         messages = special_case(messages)
@@ -64,7 +74,7 @@ class Command(BaseCommand):
                 f.write(json.dumps(formated_chats))
 
         if options['to_database']:
-            import_to_database(formated_chats)
+            import_to_database(formated_chats, options['live_run'])
 
 
 codepoint_re = re.compile(r'=([0-9A-Fa-f]{2})')
@@ -221,7 +231,7 @@ def format_chats(raw_chats):
     return formated_chats
 
 
-def import_to_database(formated_chats, _test=False):
+def import_to_database(formated_chats, live_run=False):
 
     new_users = []
     new_chats = []
@@ -296,29 +306,29 @@ def import_to_database(formated_chats, _test=False):
                 if created:
                     new_participants.append(db_participant)
 
-            if not _test:
-                print(f'\n\nNEW USERS:\n {new_users}')
-                print(f'\n\nNEW CHATS:\n {new_chats}')
-                print(f'\n\nNEW FOLLOW UPS:\n {new_follow_ups}')
-                print(f'\n\nNEW PARTICIPANTS:\n {new_participants}')
-                print(
-                    f'\n\nCreated\n'
-                    f'- {len(new_users)} new users\n'
-                    f'- {len(new_chats)} new chats\n'
-                    f'- {len(new_follow_ups)} new follow ups\n'
-                    f'- {len(new_participants)} new participants\n'
-                )
+            print(f'\n\nNEW USERS:\n {new_users}')
+            print(f'\n\nNEW CHATS:\n {new_chats}')
+            print(f'\n\nNEW FOLLOW UPS:\n {new_follow_ups}')
+            print(f'\n\nNEW PARTICIPANTS:\n {new_participants}')
+            print(
+                f'\n\nCreated\n'
+                f'- {len(new_users)} new users\n'
+                f'- {len(new_chats)} new chats\n'
+                f'- {len(new_follow_ups)} new follow ups\n'
+                f'- {len(new_participants)} new participants\n'
+            )
 
-                if sum([len(new_users), len(new_chats), len(new_follow_ups), len(new_participants)]) == 0:
-                    print('nothing to do here')
-                    raise RuntimeError('not committing')
-                answer = input('\ncommit transaction? (n/Y) > ')
-                if answer.lower() != 'y':
-                    raise RuntimeError('not committing')
-                print('committed')
+            if sum([len(new_users), len(new_chats), len(new_follow_ups), len(new_participants)]) == 0:
+                print('nothing to do here')
+                raise RuntimeError('not committing')
+            if not live_run:
+                print('THIS IS A DRY RUN ONLY - NOT COMMITTING')
+                print('Run with --live_run to actually commit.')
+                raise RuntimeError('not committing')
+            print('committed')
     except Exception as e:
         if str(e) == 'not committing':
-            print('abandoned')
+            pass
         else:
             raise
 

--- a/pennychat/management/commands/tests/test_import_google_forum.py
+++ b/pennychat/management/commands/tests/test_import_google_forum.py
@@ -93,9 +93,9 @@ def test_import_to_database():
         for user in ['A0@gmail.com', 'A1@gmail.com', 'A2@gmail.com', 'B0@gmail.com', 'C0@gmail.com']:
             assert user in users
 
-    import_to_database(formatted_forum_dump, _test=True)
+    import_to_database(formatted_forum_dump, live_run=True)
     assert_db_in_proper_state()
 
     # idempotency check
-    import_to_database(formatted_forum_dump, _test=True)
+    import_to_database(formatted_forum_dump)
     assert_db_in_proper_state()

--- a/users/management/commands/import_users_from_slack.py
+++ b/users/management/commands/import_users_from_slack.py
@@ -37,9 +37,9 @@ class Command(BaseCommand):
                     print('THIS IS A DRY RUN ONLY - NOT COMMITTING')
                     print('Run with --live_run to actually commit.')
                     raise RuntimeError('not committing')
-                print('committed')
+                print('COMMITTED')
         except Exception as e:
             if str(e) == 'not committing':
-                print('abandoned')
+                pass
             else:
                 raise

--- a/users/management/commands/import_users_from_slack.py
+++ b/users/management/commands/import_users_from_slack.py
@@ -9,6 +9,15 @@ class Command(BaseCommand):
         'Import user information from slack.'
     )
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--live_run',
+            dest='live_run',
+            action='store_true',
+            help='opposite of dry run - will actually write data to the database',
+            required=False,
+        )
+
     def handle(self, *args, **options):
         try:
             with transaction.atomic():
@@ -24,8 +33,9 @@ class Command(BaseCommand):
                 if sum([len(new_users), len(updated_users)]) == 0:
                     print('nothing to do here')
                     raise RuntimeError('not committing')
-                answer = input('\ncommit transaction? (n/Y) > ')
-                if answer.lower() != 'y':
+                if not options['live_run']:
+                    print('THIS IS A DRY RUN ONLY - NOT COMMITTING')
+                    print('Run with --live_run to actually commit.')
                     raise RuntimeError('not committing')
                 print('committed')
         except Exception as e:


### PR DESCRIPTION
closes #99 

## import_google_forum
* Must now be run by piping in the .mbox rather than supplying the path of the file. This will allow us to run the command directly against Heroku like `cat /wherever/topics.mbox | heroku run --no-tty -a <your-app> ./manage.py import_google_forum --to_database`
* Removed the user input confirmation and replaced it with a new `--live_run` arg. In both cases the output of the method lists all new objects that will be created, but this will only write to the database if `--live_run` is supplied.
* Weird note, `--live_run` can't be the last argument or command will fail for some reason. It seems to be a Heroku problem because the error is coming from a .js file on their side.


## import_users_from_slack
* Removed the user input confirmation and replaced it with a new `--live_run` arg so that it was consistent.