### PR TITLE
Shell hack

### DIFF
--- a/penny_university/apps.py
+++ b/penny_university/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class PennyUniversityConfig(AppConfig):
+    name = 'penny_university'

--- a/penny_university/management/commands/shell.py
+++ b/penny_university/management/commands/shell.py
@@ -1,0 +1,11 @@
+from django.core.management.commands.shell import Command as ShellCommand
+
+
+class Command(ShellCommand):
+    def ipython(self, options):
+        print("REMINDER - THIS IS JOHN'S HACKED SHELL - EDIT IT TO GAIN SUPERPOWERS")
+        from IPython import start_ipython
+        argv =  ['-c', 'a=3', '-i']
+
+        start_ipython(argv)
+

--- a/penny_university/management/commands/shell.py
+++ b/penny_university/management/commands/shell.py
@@ -5,7 +5,24 @@ class Command(ShellCommand):
     def ipython(self, options):
         print("REMINDER - THIS IS JOHN'S HACKED SHELL - EDIT IT TO GAIN SUPERPOWERS")
         from IPython import start_ipython
-        argv =  ['-c', 'a=3', '-i']
+
+        script_to_run_on_startup = """
+        from pennychat.models import PennyChat, PennyChatInvitation, FollowUp, Participant
+
+        from users.models import UserProfile
+
+        from slack import WebClient
+        from django.conf import settings
+        slack = WebClient(settings.SLACK_API_KEY)
+
+        expected_variables = ['WebClient']
+
+        expected_variables = expected_variables + ['In','Out','get_ipython','exit','quit', 'expected_variables']
+        available_variables = [k for k in locals().keys() if k[0] != '_' and k not in expected_variables]
+
+        print(f'\\navailable_variables:\\n{available_variables}')
+        """
+
+        argv = ['-c', script_to_run_on_startup, '-i']
 
         start_ipython(argv)
-

--- a/penny_university/settings/base.py
+++ b/penny_university/settings/base.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'home.apps.HomeConfig',
     'pennychat.apps.PennychatConfig',
     'users.apps.UsersConfig',
+    'penny_university.apps.PennyUniversityConfig',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
I got annoyed that I often needed to just open up a shell and create a slack_client or import models so I (got distracted and) figured out that it's not too hard to override the `./manage.py shell` command to do whatever you want. So I did!

you can now

```
$ ./manage.py shell

REMINDER - THIS IS JOHN'S HACKED SHELL - EDIT IT TO GAIN SUPERPOWERS
Python 3.7.6 (default, Dec 30 2019, 19:38:26) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.13.0 -- An enhanced Interactive Python. Type '?' for help.

available_variables:
['PennyChat', 'PennyChatInvitation', 'FollowUp', 'Participant', 'UserProfile', 'settings', 'slack']

In [1]: len(slack.users_list().data)                                                                                                                                                                                                          
Out[1]: 4

In [2]: PennyChat.objects.count()                                                                                                                                                                                                             
Out[2]: 5
```

I think I'll use this quite a bit. Is there any problem with this?