### PR TITLE
Moved long-running invitation slack message postings to background task runner

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 release: python manage.py migrate
-
-# MAKE USER TO USE `GUNICORN_CMD_ARGS="--workers=2"` in heroku configs (or whatever number you want) 	
 web: gunicorn penny_university.wsgi
+worker: python manage.py trash

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py migrate
 web: gunicorn penny_university.wsgi
-worker: python manage.py trash
+worker: python manage.py process_tasks

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,9 @@
 release: python manage.py migrate
 web: gunicorn penny_university.wsgi
-worker: python manage.py process_tasks
+
+
+# We also have a scheduled task to run `python manage.py process_tasks --duration 600` every 10 minutes
+# this runs background tasks that are too expensive to perform during the request cycle
+# see django-background-tasks documentation here https://django-background-tasks.readthedocs.io/en/latest/
+# see heroku scheduler tasks here https://devcenter.heroku.com/articles/scheduler
+# to edit tasks run `heroku addons:open scheduler`

--- a/bot/management/commands/send_penny_chat_template.py
+++ b/bot/management/commands/send_penny_chat_template.py
@@ -12,7 +12,6 @@ from bot.processors.pennychat import (
 from bot.tasks import organizer_edit_after_share_template, shared_message_template
 from pennychat.models import PennyChatInvitation
 from users.models import get_or_create_user_profile_from_slack_id
-# TODO! make ticket for getting this working again
 
 
 class Command(BaseCommand):

--- a/bot/management/commands/send_penny_chat_template.py
+++ b/bot/management/commands/send_penny_chat_template.py
@@ -8,11 +8,11 @@ import slack
 
 from bot.processors.pennychat import (
     shared_message_preview_template,
-    shared_message_template,
-    organizer_edit_after_share_template,
 )
+from bot.tasks import organizer_edit_after_share_template, shared_message_template
 from pennychat.models import PennyChatInvitation
 from users.models import get_or_create_user_profile_from_slack_id
+# TODO! make ticket for getting this working again
 
 
 class Command(BaseCommand):

--- a/bot/processors/pennychat.py
+++ b/bot/processors/pennychat.py
@@ -291,7 +291,6 @@ class PennyChatBotModule(BotModule):
     @has_callback_id(PENNY_CHAT_DETAILS)
     def submit_details_and_share(self, event):
         view = event['view']
-        # TODO! hide penny chat id in the value and get rid of fetch by view
         penny_chat_invitation = PennyChatInvitation.objects.get(view=view['id'])
         state = view['state']['values']
 

--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -1,0 +1,8 @@
+from background_task import background
+
+
+@background
+def do_thing():
+    print('XXXXXXXXX')
+    with open('/tmp/x', 'w') as f:
+        f.write('there')

--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -1,8 +1,0 @@
-from background_task import background
-
-
-@background
-def do_thing():
-    print('XXXXXXXXX')
-    with open('/tmp/x', 'w') as f:
-        f.write('there')

--- a/bot/tasks/__init__.py
+++ b/bot/tasks/__init__.py
@@ -1,0 +1,4 @@
+# these imports are to satisfy the requirements of django-background-tasks
+# (https://django-background-tasks.readthedocs.io/en/latest/)
+# do not import directly from this package, but instead import from the appropriate subpackage
+from bot.tasks.pennychat import *

--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -41,6 +41,7 @@ def _get_slack_client():
 
 @background
 def post_organizer_edit_after_share_template(penny_chat_view_id):
+    # TODO! test
     # TODO! replace penny_chat_view_id with penny_chat_invitation_id
     slack_client = _get_slack_client()
 
@@ -53,6 +54,7 @@ def post_organizer_edit_after_share_template(penny_chat_view_id):
 
 @background
 def share_penny_chat_invitation(penny_chat_id):
+    # TODO! teset
     penny_chat_invitation = PennyChatInvitation.objects.get(id=penny_chat_id)
     organizer = UserProfile.objects.get(  # TODO! turn this into penny_chat.organizer @property
         user_chats__penny_chat=penny_chat_invitation,

--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -49,7 +49,6 @@ def post_organizer_edit_after_share_template(penny_chat_view_id):
 @background
 def share_penny_chat_invitation(penny_chat_id):
     """Shares penny chat invitations with people and channels in the invitee list"""
-    # TODO! test
     penny_chat_invitation = PennyChatInvitation.objects.get(id=penny_chat_id)
     organizer = penny_chat_invitation.get_organizer()
     slack_client = _get_slack_client()

--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -7,14 +7,8 @@ from django.conf import settings
 from pytz import utc
 from slack import WebClient
 
-from pennychat.models import (
-    PennyChatInvitation,
-    Participant,
-)
-from users.models import (
-    get_or_create_user_profile_from_slack_ids,
-    UserProfile,
-)
+from pennychat.models import PennyChatInvitation
+from users.models import get_or_create_user_profile_from_slack_ids
 
 VIEW_SUBMISSION = 'view_submission'
 VIEW_CLOSED = 'view_closed'
@@ -54,6 +48,7 @@ def post_organizer_edit_after_share_template(penny_chat_view_id):
 
 @background
 def share_penny_chat_invitation(penny_chat_id):
+    """Shares penny chat invitations with people and channels in the invitee list"""
     # TODO! test
     penny_chat_invitation = PennyChatInvitation.objects.get(id=penny_chat_id)
     organizer = penny_chat_invitation.get_organizer()
@@ -62,11 +57,8 @@ def share_penny_chat_invitation(penny_chat_id):
     # unshare the old shares
     old_shares = json.loads(penny_chat_invitation.shares or '{}')
     for channel, ts in old_shares.items():
-        if channel[0] != 'C':
-            # skip users etc. because yu can't chat_delete messages posted to private channels
-            # TODO investigate something better to do here
-            # https://github.com/penny-university/penny_university/issues/140 might resolve this
-            continue
+        # TODO https://github.com/penny-university/penny_university/issues/140 might
+        # until this is resolved we will not be able to remove shared messages in private channels
         try:
             slack_client.chat_delete(channel=channel, ts=ts)
         except:  # noqa

--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -54,12 +54,9 @@ def post_organizer_edit_after_share_template(penny_chat_view_id):
 
 @background
 def share_penny_chat_invitation(penny_chat_id):
-    # TODO! teset
+    # TODO! test
     penny_chat_invitation = PennyChatInvitation.objects.get(id=penny_chat_id)
-    organizer = UserProfile.objects.get(  # TODO! turn this into penny_chat.organizer @property
-        user_chats__penny_chat=penny_chat_invitation,
-        user_chats__role=Participant.ORGANIZER,
-    )
+    organizer = penny_chat_invitation.get_organizer()
     slack_client = _get_slack_client()
 
     # unshare the old shares

--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -1,0 +1,204 @@
+import json
+import urllib.parse
+from datetime import timedelta
+
+from background_task import background
+from django.conf import settings
+from pytz import utc
+from slack import WebClient
+
+from pennychat.models import PennyChatInvitation
+from users.models import get_or_create_user_profile_from_slack_ids
+
+
+VIEW_SUBMISSION = 'view_submission'
+VIEW_CLOSED = 'view_closed'
+
+PENNY_CHAT_DATE = 'penny_chat_date'
+PENNY_CHAT_TIME = 'penny_chat_time'
+PENNY_CHAT_USER_SELECT = 'penny_chat_user_select'
+PENNY_CHAT_CHANNEL_SELECT = 'penny_chat_channel_select'
+PENNY_CHAT_DETAILS = 'penny_chat_details'
+PENNY_CHAT_EDIT = 'penny_chat_edit'
+PENNY_CHAT_SHARE = 'penny_chat_share'
+PENNY_CHAT_CAN_ATTEND = 'penny_chat_can_attend'
+PENNY_CHAT_CAN_NOT_ATTEND = 'penny_chat_can_not_attend'
+
+PENNY_CHAT_ID = 'penny_chat_id'
+
+
+def _get_slack_client():
+    # TODO memoize the slack_client, but remember that it has to be thread safe, so figure out some way to memoize
+    # per-thread
+    # TODO move to common/utils.py
+    return WebClient(settings.SLACK_API_KEY)
+
+
+@background
+def post_organizer_edit_after_share_template(penny_chat_view_id):
+    print("proof that it worked!")
+    # TODO! replace penny_chat_view_id with penny_chat_invitation_id
+    slack_client = _get_slack_client()
+
+    penny_chat_invitation = PennyChatInvitation.objects.get(view=penny_chat_view_id)
+    slack_client.chat_postMessage(
+        channel=penny_chat_invitation.organizer_slack_id,
+        blocks=organizer_edit_after_share_template(slack_client, penny_chat_invitation),
+    )
+
+
+def datetime_template(penny_chat):
+    timestamp = int(penny_chat.date.astimezone(utc).timestamp())
+    date_text = f'<!date^{timestamp}^{{date_pretty}} at {{time}}|{penny_chat.date}>'
+    return date_text
+
+
+def shared_message_template(penny_chat, user_name, include_rsvp=False):
+    start_date = penny_chat.date.astimezone(utc).strftime('%Y%m%dT%H%M%SZ')
+    end_date = (penny_chat.date.astimezone(utc) + timedelta(hours=1)).strftime('%Y%m%dT%H%M%SZ')
+    google_cal_url = 'https://calendar.google.com/calendar/render?' \
+                     'action=TEMPLATE&text=' \
+        f'{urllib.parse.quote(penny_chat.title)}&dates=' \
+        f'{start_date}/{end_date}&details=' \
+        f'{urllib.parse.quote(penny_chat.description)}'
+
+    body = [
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'_*{user_name}* invited you to a new Penny Chat!_'
+            }
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'*Title*\n{penny_chat.title}'
+            }
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'*Description*\n{penny_chat.description}'
+            }
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'*Date and Time*\n{datetime_template(penny_chat)}'
+            },
+            'accessory': {
+                'type': 'button',
+                'text': {
+                    'type': 'plain_text',
+                    'text': 'Add to Google Calendar :calendar:',
+                    'emoji': True
+                },
+                'url': google_cal_url
+            }
+        },
+    ]
+
+    if include_rsvp:
+        body.append(
+            {
+                'type': 'actions',
+                'elements': [
+                    {
+                        'type': 'button',
+                        'text': {
+                            'type': 'plain_text',
+                            'text': 'Count me in :thumbsup:',
+                            'emoji': True,
+                        },
+                        'action_id': PENNY_CHAT_CAN_ATTEND,
+                        'value': json.dumps({PENNY_CHAT_ID: penny_chat.id}),  # TODO should this be a helper function?
+                        'style': 'primary',
+                    },
+                    {
+                        'type': 'button',
+                        'text': {
+                            'type': 'plain_text',
+                            'text': 'I can\'t make it :thumbsdown:',
+                            'emoji': True,
+                        },
+                        'action_id': PENNY_CHAT_CAN_NOT_ATTEND,
+                        'value': json.dumps({PENNY_CHAT_ID: penny_chat.id}),
+                        'style': 'primary',
+                    }
+
+                ]
+            }
+        )
+
+    return body
+
+
+def organizer_edit_after_share_template(slack_client, penny_chat_invitation):
+    shares = []
+    users = get_or_create_user_profile_from_slack_ids(
+        comma_split(penny_chat_invitation.invitees),
+        slack_client=slack_client,
+    )
+    for slack_user_id in comma_split(penny_chat_invitation.invitees):
+        shares.append(users[slack_user_id].real_name)
+
+    organizer = get_or_create_user_profile_from_slack_ids(
+        [penny_chat_invitation.organizer_slack_id],
+        slack_client=slack_client,
+    ).get(penny_chat_invitation.organizer_slack_id)
+
+    if len(penny_chat_invitation.channels) > 0:
+        for channel in comma_split(penny_chat_invitation.channels):
+            shares.append(f'<#{channel}>')
+
+    if len(shares) == 1:
+        share_string = shares[0]
+    elif len(shares) == 2:
+        share_string = ' and '.join(shares)
+    elif len(shares) > 2:
+        shares[-1] = f'and {shares[-1]}'
+        share_string = ', '.join(shares)
+
+    shared_message_preview_blocks = shared_message_template(penny_chat_invitation, organizer.real_name) + [
+        {
+            'type': 'divider'
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'*:point_up: You just shared this invitation with:* {share_string}. '
+                    'We will notify you as invitees respond.\n\n'
+                    'In the meantime if you need to update the event, click the button below.'
+            }
+        },
+        {
+            'type': 'actions',
+            'elements': [
+                {
+                    'type': 'button',
+                    'text': {
+                        'type': 'plain_text',
+                        'text': 'Edit Details :pencil2:',
+                        'emoji': True,
+                    },
+                    # TODO should this be a helper function?
+                    'value': json.dumps({PENNY_CHAT_ID: penny_chat_invitation.id}),
+                    'action_id': PENNY_CHAT_EDIT,
+                    'style': 'primary',
+                }
+
+            ]
+        },
+    ]
+
+    return shared_message_preview_blocks
+
+
+def comma_split(comma_delimited_string):
+    """normal string split for  ''.split(',') returns [''], so using this instead"""
+    return [x for x in comma_delimited_string.split(',') if x]

--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -35,8 +35,6 @@ def _get_slack_client():
 
 @background
 def post_organizer_edit_after_share_template(penny_chat_view_id):
-    # TODO! test
-    # TODO! replace penny_chat_view_id with penny_chat_invitation_id
     slack_client = _get_slack_client()
 
     penny_chat_invitation = PennyChatInvitation.objects.get(view=penny_chat_view_id)
@@ -166,6 +164,7 @@ def shared_message_template(penny_chat, user_name, include_rsvp=False):
 
 
 def organizer_edit_after_share_template(slack_client, penny_chat_invitation):
+    # TODO! test
     shares = []
     users = get_or_create_user_profile_from_slack_ids(
         comma_split(penny_chat_invitation.invitees),

--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -164,7 +164,6 @@ def shared_message_template(penny_chat, user_name, include_rsvp=False):
 
 
 def organizer_edit_after_share_template(slack_client, penny_chat_invitation):
-    # TODO! test
     shares = []
     users = get_or_create_user_profile_from_slack_ids(
         comma_split(penny_chat_invitation.invitees),

--- a/bot/tests/processors/test_pennychat.py
+++ b/bot/tests/processors/test_pennychat.py
@@ -148,7 +148,7 @@ def test_PennyChatBotModule_share(mocker):
     slack_client = mocker.Mock()
     slack_client.chat_postMessage().data = {'channel': 'share_chan', 'ts': 'share_ts'}
 
-    with mocker.patch('bot.processors.pennychat.get_or_create_user_profile_from_slack_ids', side_effect=ids_mock), \
+    with mocker.patch('bot.tasks.pennychat.get_or_create_user_profile_from_slack_ids', side_effect=ids_mock), \
             mocker.patch('bot.processors.pennychat.get_or_create_user_profile_from_slack_id', side_effect=id_mock), \
             mocker.patch('bot.processors.pennychat.requests'):
 

--- a/bot/tests/processors/test_pennychat.py
+++ b/bot/tests/processors/test_pennychat.py
@@ -108,15 +108,12 @@ def test_PennyChatBotModule_share(mocker):
         description='fake description',
     )
 
-    def ids_mock(user_ids, slack_client=None):
+    def id_mock(user_id, slack_client=None, ignore_user_not_found=True):
         lookup = {
             organizer.slack_id: organizer,
             user_invitee_1.slack_id: user_invitee_1,
         }
-        return {user_id: lookup[user_id] for user_id in user_ids}
-
-    def id_mock(user_id, slack_client=None, ignore_user_not_found=True):
-        return ids_mock([user_id], slack_client).get(user_id)
+        return lookup[user_id]
 
     event = {
         'user': {
@@ -151,7 +148,6 @@ def test_PennyChatBotModule_share(mocker):
     )
 
     # The Actual Test
-    # TODO! remove get_or_create_user_profile_from_slack_ids mocks everywhere
     with mocker.patch('pennychat.models.get_or_create_user_profile_from_slack_id', side_effect=id_mock), \
             post_organizer_edit_after_share_template:
         PennyChatBotModule(mocker.Mock()).submit_details_and_share(event)

--- a/bot/tests/processors/test_pennychat.py
+++ b/bot/tests/processors/test_pennychat.py
@@ -115,7 +115,7 @@ def test_PennyChatBotModule_share(mocker):
         }
         return {user_id: lookup[user_id] for user_id in user_ids}
 
-    def id_mock(user_id, slack_client=None):
+    def id_mock(user_id, slack_client=None, ignore_user_not_found=True):
         return ids_mock([user_id], slack_client).get(user_id)
 
     event = {

--- a/bot/tests/tasks/test_pennychat.py
+++ b/bot/tests/tasks/test_pennychat.py
@@ -1,18 +1,19 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
 import json
 from unittest.mock import call
 
 from django.utils import timezone
 import pytest
 
-from bot.tasks import share_penny_chat_invitation
+from bot.tasks import share_penny_chat_invitation, post_organizer_edit_after_share_template, \
+    organizer_edit_after_share_template
 from pennychat.models import PennyChatInvitation
 from users.models import UserProfile
 
 
 @pytest.mark.django_db
 def test_share_penny_chat_invitation(mocker):
-    chat = PennyChatInvitation.objects.create(
+    penny_chat = PennyChatInvitation.objects.create(
         title='Chat 1',
         description='The first test chat',
         date=timezone.now() - timedelta(weeks=4),
@@ -20,7 +21,7 @@ def test_share_penny_chat_invitation(mocker):
         channels='itsy,bitsy,spider'
     )
     user_profile = UserProfile.objects.create(slack_id='x', display_name='booger')
-    chat.save_organizer(user_profile)
+    penny_chat.save_organizer(user_profile)
 
     slack_client = mocker.Mock()
 
@@ -42,15 +43,15 @@ def test_share_penny_chat_invitation(mocker):
 
     # test 1 - on first call it should send all the invitations
     with mocker.patch('bot.tasks.pennychat._get_slack_client', return_value=slack_client):
-        share_penny_chat_invitation.now(chat.id)
+        share_penny_chat_invitation.now(penny_chat.id)
 
     shared_with = set([cal[1]['channel'] for cal in slack_client.chat_postMessage.call_args_list])
     assert shared_with == {'itsy', 'bitsy', 'spider', 'foo', 'man', 'choo'}
     assert not slack_client.chat_delete.called
 
-    chat.refresh_from_db()
+    penny_chat.refresh_from_db()
 
-    assert json.loads(chat.shares) == {
+    assert json.loads(penny_chat.shares) == {
         'itsy': 1234,
         'bitsy': 1234,
         'spider': 1234,
@@ -68,14 +69,14 @@ def test_share_penny_chat_invitation(mocker):
     # test 2 - on second call it should first delete all the old invitations and send the new ones
 
     # change these just to make sure that the change is being picked up.
-    chat.invitees = 'foo,man'
-    chat.channels = 'itsy,bitsy'
-    chat.save()
+    penny_chat.invitees = 'foo,man'
+    penny_chat.channels = 'itsy,bitsy'
+    penny_chat.save()
 
     slack_client.chat_postMessage.reset_mock()
 
     with mocker.patch('bot.tasks.pennychat._get_slack_client', return_value=slack_client):
-        share_penny_chat_invitation.now(chat.id)
+        share_penny_chat_invitation.now(penny_chat.id)
 
     shared_with = set([cal[1]['channel'] for cal in slack_client.chat_postMessage.call_args_list])
     assert shared_with == {'man', 'itsy', 'bitsy', 'foo'}
@@ -88,11 +89,73 @@ def test_share_penny_chat_invitation(mocker):
         call(channel='choo', ts=1234),
     ]
 
-    chat.refresh_from_db()
+    penny_chat.refresh_from_db()
 
-    assert json.loads(chat.shares) == {
+    assert json.loads(penny_chat.shares) == {
         'itsy': 5678,
         'bitsy': 5678,
         'foo': 5678,
         'man': 5678,
     }
+
+
+@pytest.mark.django_db
+def test_post_organizer_edit_after_share_template(mocker):
+    penny_chat_view_id = 'some_view_id'
+    organizer_slack_id = 'some_organizer_slack_id'
+
+    PennyChatInvitation.objects.create(
+        title='Chat 1',
+        view=penny_chat_view_id,
+        organizer_slack_id=organizer_slack_id,
+    )
+
+    slack_client = mocker.Mock()
+
+    class chat_postMessage:
+        def __init__(self, timestamp):
+            self.call_num = -1
+            self.timestamp = timestamp
+
+        def __call__(self, channel, blocks):
+            self.call_num += 1
+            chat_postMessage_resp = mocker.Mock()
+            chat_postMessage_resp.data = {
+                'channel': channel,
+                'ts': self.timestamp,
+            }
+            return chat_postMessage_resp
+
+    slack_client.chat_postMessage.side_effect = chat_postMessage(1234)
+
+    with mocker.patch('bot.tasks.pennychat._get_slack_client', return_value=slack_client),\
+            mocker.patch('bot.tasks.pennychat.organizer_edit_after_share_template', return_value='some_block'):
+        post_organizer_edit_after_share_template.now(penny_chat_view_id),
+
+    assert slack_client.chat_postMessage.call_args == call(blocks='some_block', channel='some_organizer_slack_id')
+
+
+@pytest.mark.django_db
+def test_organizer_edit_after_share_template(mocker):
+    user_1 = UserProfile.objects.create(slack_id='user_1', real_name='user_1')
+    user_2 = UserProfile.objects.create(slack_id='user_2', real_name='user_2')
+    organizer = UserProfile.objects.create(slack_id='organizer', real_name='Orlando')
+
+    penny_chat = PennyChatInvitation.objects.create(
+        title='Chat 1',
+        invitees='user_1,user_2',
+        organizer_slack_id='organizer',
+        channels='Chan1,Chan2',
+    )
+
+    def ids_mock(user_ids, slack_client=None):
+        return {user.slack_id: user for user in [user_1, user_2, organizer] if user.slack_id in user_ids}
+
+    slack_client = mocker.Mock()
+
+    with mocker.patch('bot.tasks.pennychat.get_or_create_user_profile_from_slack_ids', side_effect=ids_mock),\
+            mocker.patch('bot.tasks.pennychat.shared_message_template', return_value=['some_blocks']):
+        template = str(organizer_edit_after_share_template(slack_client, penny_chat))
+
+    assert 'some_blocks' in template
+    assert 'You just shared this invitation with:* user_1, user_2, <#Chan1>, and <#Chan2>.' in template

--- a/bot/tests/tasks/test_pennychat.py
+++ b/bot/tests/tasks/test_pennychat.py
@@ -1,0 +1,98 @@
+from datetime import timedelta
+import json
+from unittest.mock import call
+
+from django.utils import timezone
+import pytest
+
+from bot.tasks import share_penny_chat_invitation
+from pennychat.models import PennyChatInvitation
+from users.models import UserProfile
+
+
+@pytest.mark.django_db
+def test_share_penny_chat_invitation(mocker):
+    chat = PennyChatInvitation.objects.create(
+        title='Chat 1',
+        description='The first test chat',
+        date=timezone.now() - timedelta(weeks=4),
+        invitees='foo,man,choo',
+        channels='itsy,bitsy,spider'
+    )
+    user_profile = UserProfile.objects.create(slack_id='x', display_name='booger')
+    chat.save_organizer(user_profile)
+
+    slack_client = mocker.Mock()
+
+    class chat_postMessage:
+        def __init__(self, timestamp):
+            self.call_num = -1
+            self.timestamp = timestamp
+
+        def __call__(self, channel, blocks):
+            self.call_num += 1
+            chat_postMessage_resp = mocker.Mock()
+            chat_postMessage_resp.data = {
+                'channel': channel,
+                'ts': self.timestamp,
+            }
+            return chat_postMessage_resp
+
+    slack_client.chat_postMessage.side_effect = chat_postMessage(1234)
+
+    # test 1 - on first call it should send all the invitations
+    with mocker.patch('bot.tasks.pennychat._get_slack_client', return_value=slack_client):
+        share_penny_chat_invitation.now(chat.id)
+
+    shared_with = set([cal[1]['channel'] for cal in slack_client.chat_postMessage.call_args_list])
+    assert shared_with == {'itsy', 'bitsy', 'spider', 'foo', 'man', 'choo'}
+    assert not slack_client.chat_delete.called
+
+    chat.refresh_from_db()
+
+    assert json.loads(chat.shares) == {
+        'itsy': 1234,
+        'bitsy': 1234,
+        'spider': 1234,
+        'foo': 1234,
+        'man': 1234,
+        'choo': 1234,
+    }
+
+    blocks = slack_client.chat_postMessage.call_args[1]['blocks']
+    assert blocks
+    assert 'invited you to a new Penny Chat' in str(blocks)
+
+    slack_client.chat_postMessage.side_effect = chat_postMessage(5678)
+
+    # test 2 - on second call it should first delete all the old invitations and send the new ones
+
+    # change these just to make sure that the change is being picked up.
+    chat.invitees = 'foo,man'
+    chat.channels = 'itsy,bitsy'
+    chat.save()
+
+    slack_client.chat_postMessage.reset_mock()
+
+    with mocker.patch('bot.tasks.pennychat._get_slack_client', return_value=slack_client):
+        share_penny_chat_invitation.now(chat.id)
+
+    shared_with = set([cal[1]['channel'] for cal in slack_client.chat_postMessage.call_args_list])
+    assert shared_with == {'man', 'itsy', 'bitsy', 'foo'}
+    assert slack_client.chat_delete.call_args_list == [
+        call(channel='itsy', ts=1234),
+        call(channel='bitsy', ts=1234),
+        call(channel='spider', ts=1234),
+        call(channel='foo', ts=1234),
+        call(channel='man', ts=1234),
+        call(channel='choo', ts=1234),
+    ]
+
+    chat.refresh_from_db()
+
+    assert json.loads(chat.shares) == {
+        'itsy': 5678,
+        'bitsy': 5678,
+        'foo': 5678,
+        'man': 5678,
+    }

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -1,0 +1,5 @@
+# Development Setup
+
+**NOTE:** this is a work in progress. [We are developing notes here](https://docs.google.com/document/d/1d3o2IkOg4z93c-l6w_cF8kKCM36DkxTq8Wpj7JMbQtw/edit) that will soon fill in the missing pieces in this file.
+
+ 

--- a/penny_university/management/commands/trash.py
+++ b/penny_university/management/commands/trash.py
@@ -1,8 +1,0 @@
-import time
-
-from django.core.management.base import BaseCommand
-
-
-class Command(BaseCommand):
-    def handle(self, *args, **options):
-        print('YYYYYYYYY')

--- a/penny_university/management/commands/trash.py
+++ b/penny_university/management/commands/trash.py
@@ -1,0 +1,12 @@
+import time
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        i = 0
+        while True:
+            i += 1
+            print(i, 'XXXXXXXXX')
+            time.sleep(5.0)

--- a/penny_university/management/commands/trash.py
+++ b/penny_university/management/commands/trash.py
@@ -5,8 +5,4 @@ from django.core.management.base import BaseCommand
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        i = 0
-        while True:
-            i += 1
-            print(i, 'XXXXXXXXX')
-            time.sleep(5.0)
+        print('YYYYYYYYY')

--- a/penny_university/settings/base.py
+++ b/penny_university/settings/base.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'background_task',
     'corsheaders',
     'rest_framework',
     'bot.apps.BotConfig',

--- a/penny_university/settings/base.py
+++ b/penny_university/settings/base.py
@@ -40,12 +40,12 @@ INSTALLED_APPS = [
     'background_task',
     'corsheaders',
     'rest_framework',
-    'bot.apps.BotConfig',
-    'api.apps.ApiConfig',
-    'home.apps.HomeConfig',
-    'pennychat.apps.PennychatConfig',
-    'users.apps.UsersConfig',
-    'penny_university.apps.PennyUniversityConfig',
+    'bot',
+    'api',
+    'home',
+    'pennychat',
+    'users',
+    'penny_university',
 ]
 
 MIDDLEWARE = [

--- a/pennychat/models.py
+++ b/pennychat/models.py
@@ -33,16 +33,15 @@ class PennyChat(models.Model):
         return pprint_obj(self)
 
     def save_organizer_from_slack_id(self, slack_user_id):
-        organizer = get_or_create_user_profile_from_slack_id(slack_user_id)
+        organizer = get_or_create_user_profile_from_slack_id(slack_user_id, ignore_user_not_found=False)
         self.save_organizer(organizer)
 
     def save_organizer(self, organizer):
-        if organizer:
-            Participant.objects.update_or_create(
-                penny_chat=self,
-                user=organizer,
-                defaults=dict(role=Participant.ORGANIZER),
-            )
+        Participant.objects.update_or_create(
+            penny_chat=self,
+            user=organizer,
+            defaults=dict(role=Participant.ORGANIZER),
+        )
 
     def get_organizer(self):
         organizer = UserProfile.objects.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 django>=2.1.10
 dj-database-url==0.5.0
+django-background-tasks==1.2.5
 gunicorn==19.9.0
 python-dateutil==2.8.1
 slackclient>=2.2.0

--- a/users/models.py
+++ b/users/models.py
@@ -112,8 +112,7 @@ def get_or_create_user_profile_from_slack_ids(slack_user_ids, slack_client=None,
         try:
             # call slack every time rather than just seeing if the user is in the database just in case slack contains
             # updated information
-            # TODO add request-level or time-based caching since it's unlikely that slack has been updated
-            #  within the time of the request
+            # TODO get the user out of the db and only check slack if the update_at is older than some cutoff
             slack_user = slack_client.users_info(user=slack_user_id).data['user']
         except SlackApiError as e:
             if ignore_user_not_found and "'error': 'user_not_found'" in str(e):


### PR DESCRIPTION
# What
Moved long-running invitation slack message postings to background task runner

# Why
Because we have a 3 second deadline to return to the slack API, and these messages were taking an arbitrarily long time to send depending upon how many users were invited to a penny chat.

# Related
parent https://github.com/penny-university/penny_university/issues/153
