### PR TITLE
Remove confusing pretty date formats

### DIFF
--- a/bot/tasks/pennychat.py
+++ b/bot/tasks/pennychat.py
@@ -75,7 +75,7 @@ def share_penny_chat_invitation(penny_chat_id):
 
 def datetime_template(penny_chat):
     timestamp = int(penny_chat.date.astimezone(utc).timestamp())
-    date_text = f'<!date^{timestamp}^{{date_pretty}} at {{time}}|{penny_chat.date}>'
+    date_text = f'<!date^{timestamp}^{{date}} at {{time}}|{penny_chat.date}>'
     return date_text
 
 


### PR DESCRIPTION
## What

Change display of Penny Chat date times from 

```
Date and Time
Today at 11:30 PM
```

to

```
Date and Time
April 9th at 11:30 PM
```

## Why

Today, tomorrow, etc are confusing when participants are in different time zones. 

## Related

Closes https://github.com/penny-university/penny_university/issues/157
