### PR TITLE
Remove another confusing pretty date formats

### DIFF
--- a/bot/processors/pennychat.py
+++ b/bot/processors/pennychat.py
@@ -382,7 +382,7 @@ class PennyChatBotModule(BotModule):
 
             # create organizer notification message (even if we choose not to use it below)
             timestamp = int(penny_chat.date.astimezone(utc).timestamp())
-            date_text = f'<!date^{timestamp}^{{date_pretty}} at {{time}}|{penny_chat.date}>'
+            date_text = f'<!date^{timestamp}^{{date}} at {{time}}|{penny_chat.date}>'
             _not = '' if participant_role == Participant.ATTENDEE else ' _not_'
             notification = f'<@{user.slack_id}> will{_not} attend your Penny Chat "{penny_chat.title}" ({date_text})'
             we_will_notify_organizer = 'Thank you. We will notify the organizer.'


### PR DESCRIPTION
## What

Fix the date format on the notification after recipient accepts the invite. 

![image](https://user-images.githubusercontent.com/21176245/79048942-801c6980-7bee-11ea-9550-7b889ce49cf6.png)

Change display of Penny Chat date times from 

```
Date and Time
Today at 11:30 PM
```

to

```
Date and Time
April 9th at 11:30 PM
```

## Why

Today, tomorrow, etc are confusing when participants are in different time zones. 

## Related

* Closes https://github.com/penny-university/penny_university/issues/157
* https://github.com/penny-university/penny_university/pull/165

## Screenshots

The problem where the host and participant seeing a different date time format seems to have resolved the day after

![Image from iOS](https://user-images.githubusercontent.com/21176245/79048923-5fecaa80-7bee-11ea-8a0b-61b85203c92c.png)

