### PR TITLE
requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ dj-rest-auth==1.0.1
 
 # I had a little trouble installing psycopg2, this finally worked
 # brew install postgres
-# LDFLAGS='-L/usr/local/lib -L/usr/local/opt/openssl/lib -L/usr/local/opt/readline/lib' pip install psycopg2
-psycopg2==2.8.3
+# LDFLAGS='-L/usr/local/lib -L/usr/local/opt/openssl/lib -L/usr/local/opt/readline/lib' pip install psycopg2>=2.8
+psycopg2>=2.8


### PR DESCRIPTION
I updated a confusing part of installation. After running into an install issue with postgres I followed the comment but still couldn't successfully run a `pip install -r requirements.txt`. This fixes it (if the check on this PR pass!).