### PR TITLE
Break out homepage scss and compile it to static dir

### DIFF
--- a/penny_university_frontend/package.json
+++ b/penny_university_frontend/package.json
@@ -42,7 +42,7 @@
     "lint:fix": "yarn lint --fix",
     "lint:scss": "sass-lint -v $npm_package_config_src_css",
     "lint:scss:fix": "sass-lint-auto-fix",
-    "compile:css": "node-sass-chokidar --include-path ./src --include-path ../scss --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css",
+    "compile:css": "node-sass-chokidar --include-path ./src --include-path ../scss --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css && cp ./home.css ../../penny_university/static/css/styles.css",
     "watch:css": "yarn run compile:css && node-sass-chokidar --include-path ../scss --include-path ./src --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css --watch --recursive"
   },
   "browserslist": {

--- a/penny_university_frontend/package.json
+++ b/penny_university_frontend/package.json
@@ -42,7 +42,7 @@
     "lint:fix": "npm lint --fix",
     "lint:scss": "sass-lint -v $npm_package_config_src_css",
     "lint:scss:fix": "sass-lint-auto-fix",
-    "compile:css": "node-sass-chokidar --include-path ./src --include-path ../scss --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css && cp ./home.css ../../penny_university/static/css/styles.css",
+    "compile:css": "node-sass-chokidar --include-path ./src --include-path ../scss --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css && cp ./src/home.css ../penny_university/static/css/styles.css",
     "watch:css": "npm run compile:css && node-sass-chokidar --include-path ../scss --include-path ./src --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css --watch --recursive"
   },
   "browserslist": {

--- a/penny_university_frontend/package.json
+++ b/penny_university_frontend/package.json
@@ -39,11 +39,11 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src/ --ext .js,.jsx",
-    "lint:fix": "yarn lint --fix",
+    "lint:fix": "npm lint --fix",
     "lint:scss": "sass-lint -v $npm_package_config_src_css",
     "lint:scss:fix": "sass-lint-auto-fix",
     "compile:css": "node-sass-chokidar --include-path ./src --include-path ../scss --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css && cp ./home.css ../../penny_university/static/css/styles.css",
-    "watch:css": "yarn run compile:css && node-sass-chokidar --include-path ../scss --include-path ./src --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css --watch --recursive"
+    "watch:css": "npm run compile:css && node-sass-chokidar --include-path ../scss --include-path ./src --include-path ./node_modules $npm_package_config_src_css -o $npm_package_config_dest_css --watch --recursive"
   },
   "browserslist": {
     "production": [

--- a/penny_university_frontend/scss/_main.scss
+++ b/penny_university_frontend/scss/_main.scss
@@ -18,14 +18,6 @@ pre {
   position: fixed;
 }
 
-.btn-red {
-  @extend .btn-danger;
-}
-
-.btn-outline-red {
-  @extend .btn-outline-danger;
-}
-
 .overlay-text {
   position: relative;
   z-index: 1;
@@ -54,26 +46,6 @@ h1, h2, h3, .navbar-brand {
   text-transform: capitalize;
 }
 
-/* Style all font awesome icons */
-.social-icons {
-  .fa {
-    border-radius: 50%;
-    font-size: 20px;
-    height: 40px;
-    margin: 0 5px;
-    padding: 10px;
-    text-align: center;
-    text-decoration: none;
-    width: 40px;
-
-    &:hover {
-      color: $white;
-      opacity: 0.7;
-      text-decoration: none;
-    }
-  }
-}
-
 /* Set a specific color for each brand */
 .fa-facebook {
   background: #3b5998;
@@ -88,15 +60,4 @@ h1, h2, h3, .navbar-brand {
 .fa-twitter {
   background: #55acee;
   color: #fff;
-}
-
-.icon__user {
-  align-items: center;
-  border-radius: 50%;
-  display: flex;
-  font-size: 1rem;
-  height: 3rem;
-  justify-content: center;
-  text-align: center;
-  width: 3rem;
 }

--- a/penny_university_frontend/src/home.scss
+++ b/penny_university_frontend/src/home.scss
@@ -1,0 +1,1 @@
+@import '../scss/main'

--- a/penny_university_frontend/src/style.css
+++ b/penny_university_frontend/src/style.css
@@ -7180,6 +7180,19 @@ pre {
 h1, h2, h3, .navbar-brand {
   text-transform: capitalize; }
 
+/* Set a specific color for each brand */
+.fa-facebook {
+  background: #3b5998;
+  color: #fff; }
+
+.fa-instagram {
+  background: #d30f62;
+  color: #fff; }
+
+.fa-twitter {
+  background: #55acee;
+  color: #fff; }
+
 /* Style all font awesome icons */
 .social-icons .fa {
   border-radius: 50%;
@@ -7194,19 +7207,6 @@ h1, h2, h3, .navbar-brand {
     color: #fff;
     opacity: 0.7;
     text-decoration: none; }
-
-/* Set a specific color for each brand */
-.fa-facebook {
-  background: #3b5998;
-  color: #fff; }
-
-.fa-instagram {
-  background: #d30f62;
-  color: #fff; }
-
-.fa-twitter {
-  background: #55acee;
-  color: #fff; }
 
 .icon__user {
   align-items: center;

--- a/penny_university_frontend/src/style.scss
+++ b/penny_university_frontend/src/style.scss
@@ -1,1 +1,41 @@
-@import 'scss/main'
+@import '../scss/main';
+
+
+.btn-red {
+  @extend .btn-danger;
+}
+
+.btn-outline-red {
+  @extend .btn-outline-danger;
+}
+
+/* Style all font awesome icons */
+.social-icons {
+  .fa {
+    border-radius: 50%;
+    font-size: 20px;
+    height: 40px;
+    margin: 0 5px;
+    padding: 10px;
+    text-align: center;
+    text-decoration: none;
+    width: 40px;
+
+    &:hover {
+      color: $white;
+      opacity: 0.7;
+      text-decoration: none;
+    }
+  }
+}
+
+.icon__user {
+  align-items: center;
+  border-radius: 50%;
+  display: flex;
+  font-size: 1rem;
+  height: 3rem;
+  justify-content: center;
+  text-align: center;
+  width: 3rem;
+}


### PR DESCRIPTION
Nick pointed out that I inadvertently broke the compilation for the home page css.

I updated our css files to break out home page and app scss. The homepage doesn't have the extra app scss based on the committed  home page css file but it is possible that the app has extra home page css still.

While the home page is separate, I added an extra command to the compilation script that copies the home page css to the static dir.