### PR TITLE
Make date a required field for the penny chat serializer

### DIFF
--- a/pennychat/serializers.py
+++ b/pennychat/serializers.py
@@ -42,6 +42,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
 class PennyChatSerializer(serializers.HyperlinkedModelSerializer):
     follow_ups = serializers.HyperlinkedIdentityField(view_name='followup-list')
     participants = ParticipantSerializer(many=True, read_only=True)
+    date = serializers.DateTimeField(required=True)
 
     class Meta:
         model = PennyChat

--- a/pennychat/tests/api/test_penny_chat.py
+++ b/pennychat/tests/api/test_penny_chat.py
@@ -57,6 +57,21 @@ def test_create_penny_chat(test_chats_1):
 
 
 @pytest.mark.django_db
+def test_create_penny_chat_without_date(test_chats_1):
+    user = test_chats_1[0].get_organizer().user
+    token = Token.objects.create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+    data = {
+        'title': 'Create Chat',
+        'description': 'Testing creating a chat'
+    }
+    response = client.post('/api/chats/', data=data, format='json')
+    assert response.status_code == 400
+    assert response.data['date'][0].code == 'required'
+
+
+@pytest.mark.django_db
 def test_create_penny_chat_unauthorized(test_chats_1):
     client = APIClient()
     data = {


### PR DESCRIPTION
## What
Previously, we could create chats without a date using the Rest API. I changed the date field to be required on the PennyChatSerializer, and added some tests.

## Evidence
When you attempt to create a penny chat without a date, it returns an error.
![Screen Shot 2020-04-17 at 5 45 57 PM](https://user-images.githubusercontent.com/31971995/79619792-82416500-80d3-11ea-9d45-2b235589138d.png)
