### PR TITLE
After people join, automatically post in the welcome room.

### DIFF
--- a/bot/tests/processors/test_greeting.py
+++ b/bot/tests/processors/test_greeting.py
@@ -19,11 +19,15 @@ def test_greeting(mocker):
         'channel_type': 'channel'
     }
     with mocker.patch('bot.processors.greeting.greeting_blocks', return_value='welcome'), \
+            mocker.patch('bot.processors.greeting.welcome_room_blocks', return_value='arrive'), \
             mocker.patch('bot.processors.greeting.notify_admins'), \
-            mocker.patch('bot.processors.filters.channel_lookup', return_value='GENERAL'):
-
+            mocker.patch('bot.processors.filters.channel_lookup', return_value='GENERAL'), \
+            mocker.patch('bot.processors.greeting.channel_lookup', return_value='WELCOME_CHANNEL'):
         greeter(event)
-    assert slack.chat_postMessage.call_args == mocker.call(channel='U42HCBFEF', blocks='welcome')
+    slack.chat_postMessage.assert_has_calls([
+        mocker.call(channel='U42HCBFEF', blocks='welcome'),
+        mocker.call(channel='WELCOME_CHANNEL', blocks='arrive')
+    ], any_order=True)
 
 
 def test_greeting_wrong_channel(mocker):


### PR DESCRIPTION
## What

When a new user joins `general` channel, post a message in `penny-u-welcome-committee` channel that says

```
@some_user just arrived. Can anyone reach out to them to set up a 15 minute chat?
```

![image](https://user-images.githubusercontent.com/21176245/80853461-29a7b700-8bff-11ea-8fea-880f463be77b.png)

Note: requires scope for bot to write messages to channel e.g. `chat:write` 

## Why

Currently, when a new user joins, John has to post a message in the `penny-u-welcome-committee` manually. This automates the process.

## Related

#39 - see 2nd half of https://github.com/penny-university/penny_university/issues/39#issuecomment-617529183