### PR TITLE
Replace Join Us modal to use permanent invitation link

### DIFF
--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -25,12 +25,8 @@
                     <a href="https://twitter.com/officialpennyu" class="fa fa-twitter"></a>
                     <a href="https://www.instagram.com/officialpennyu" class="fa fa-instagram"></a>
                 </div>
-                <button type="button" class="ml-2 btn btn-outline-dark"
-                        {% if invite_link %}
-                        onclick=" window.open('{{ invite_link }}','_blank')"
-                        {% else %}
-                        data-toggle="modal" data-target="#formModal"
-                        {% endif %}>
+                <button type="button" class="ml-2 btn btn-outline-dark" data-toggle="modal"
+                        data-target="#formModal">
                     Join Us! <i class="fa fa-slack"></i>
                 </button>
             </div>
@@ -44,12 +40,7 @@
                 <h1 class="display-4">Penny University</h1>
                 <h3 class="mt-4">A peer to peer learning community</h3>
                 <div class="mt-4">
-                    <button type="button" class="btn btn-lg btn-primary"
-                            {% if invite_link %}
-                            onclick=" window.open('{{ invite_link }}','_blank')"
-                            {% else %}
-                            data-toggle="modal" data-target="#formModal"
-                            {% endif %}>
+                    <button type="button" class="btn btn-lg btn-primary" data-toggle="modal" data-target="#formModal">
                         Join Us On Slack! <i class="fa fa-slack"></i>
                     </button>
                 </div>
@@ -127,12 +118,7 @@
                         Penny Chats with one another to in order to share knowledge, and then write up what
                         they've learned and share it with the community.
                     </p>
-                    <button type="button" class="btn btn-lg btn-primary"
-                            {% if invite_link %}
-                            onclick=" window.open('{{ invite_link }}','_blank')"
-                            {% else %}
-                            data-toggle="modal" data-target="#formModal"
-                            {% endif %}>
+                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#formModal">
                         Join Us On Slack! <i class="fa fa-slack"></i>
                     </button>
                     <div class="mt-3">
@@ -153,12 +139,8 @@
             <a href="https://twitter.com/officialpennyu" class="fa fa-twitter"></a>
             <a href="https://www.instagram.com/officialpennyu" class="fa fa-instagram"></a>
         </div>
-        <button type="button" class="ml-2 btn btn-outline-dark"
-                {% if invite_link %}
-                onclick=" window.open('{{ invite_link }}','_blank')"
-                {% else %}
-                data-toggle="modal" data-target="#formModal"
-                {% endif %}>
+        <button type="button" class="ml-2 btn btn-outline-dark" data-toggle="modal"
+                data-target="#formModal">
             Join Us! <i class="fa fa-slack"></i>
         </button>
     </footer>

--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -25,8 +25,12 @@
                     <a href="https://twitter.com/officialpennyu" class="fa fa-twitter"></a>
                     <a href="https://www.instagram.com/officialpennyu" class="fa fa-instagram"></a>
                 </div>
-                <button type="button" class="ml-2 btn btn-outline-dark" data-toggle="modal"
-                        data-target="#formModal">
+                <button type="button" class="ml-2 btn btn-outline-dark"
+                        {% if invite_link %}
+                        onclick=" window.open('{{ invite_link }}','_blank')"
+                        {% else %}
+                        data-toggle="modal" data-target="#formModal"
+                        {% endif %}>
                     Join Us! <i class="fa fa-slack"></i>
                 </button>
             </div>
@@ -40,7 +44,12 @@
                 <h1 class="display-4">Penny University</h1>
                 <h3 class="mt-4">A peer to peer learning community</h3>
                 <div class="mt-4">
-                    <button type="button" class="btn btn-lg btn-primary" data-toggle="modal" data-target="#formModal">
+                    <button type="button" class="btn btn-lg btn-primary"
+                            {% if invite_link %}
+                            onclick=" window.open('{{ invite_link }}','_blank')"
+                            {% else %}
+                            data-toggle="modal" data-target="#formModal"
+                            {% endif %}>
                         Join Us On Slack! <i class="fa fa-slack"></i>
                     </button>
                 </div>
@@ -118,7 +127,12 @@
                         Penny Chats with one another to in order to share knowledge, and then write up what
                         they've learned and share it with the community.
                     </p>
-                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#formModal">
+                    <button type="button" class="btn btn-lg btn-primary"
+                            {% if invite_link %}
+                            onclick=" window.open('{{ invite_link }}','_blank')"
+                            {% else %}
+                            data-toggle="modal" data-target="#formModal"
+                            {% endif %}>
                         Join Us On Slack! <i class="fa fa-slack"></i>
                     </button>
                     <div class="mt-3">
@@ -139,8 +153,12 @@
             <a href="https://twitter.com/officialpennyu" class="fa fa-twitter"></a>
             <a href="https://www.instagram.com/officialpennyu" class="fa fa-instagram"></a>
         </div>
-        <button type="button" class="ml-2 btn btn-outline-dark" data-toggle="modal"
-                data-target="#formModal">
+        <button type="button" class="ml-2 btn btn-outline-dark"
+                {% if invite_link %}
+                onclick=" window.open('{{ invite_link }}','_blank')"
+                {% else %}
+                data-toggle="modal" data-target="#formModal"
+                {% endif %}>
             Join Us! <i class="fa fa-slack"></i>
         </button>
     </footer>

--- a/home/templates/home/modal.html
+++ b/home/templates/home/modal.html
@@ -11,23 +11,18 @@
                 {% csrf_token %}
                 <div class="modal-body">
                     <p class="font-weight-light">
-                        Give us your email address and we will add you to our Slack group.
-                        You will also be able to add your own Penny Chat Reviews to our Google Forum.
+                        The Penny University community hangs out in Slack.
+                        Click the button below to go to our Slack sign-up page.
                     </p>
-                    {% for field in form %}
-                        <div class="form-group">
-                            {{ field.errors }}
-                            {{ field.label_tag }}
-                            {{ field }}
-                            {% if field.help_text %}
-                                <small class="form-text text-muted">{{ field.help_text|safe }}</small>
-                            {% endif %}
-                        </div>
-                    {% endfor %}
+                    <p>Not sure yet?
+                            <a href="https://groups.google.com/forum/#!forum/penny-university">
+                                Check out what we've been up to on our forum.
+                            </a>
+                        </p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                    <button type="submit" class="btn btn-primary">Submit</button>
+                    <button type="submit" class="btn btn-primary">Join Penny University</button>
                 </div>
             </form>
         </div>

--- a/home/templates/home/modal.html
+++ b/home/templates/home/modal.html
@@ -15,11 +15,6 @@
                         The Penny University community hangs out in Slack.
                         Click the button below to go to our Slack sign-up page.
                     </p>
-                    <p>Not sure yet?
-                            <a href="https://groups.google.com/forum/#!forum/penny-university">
-                                Check out what we've been up to on our forum.
-                            </a>
-                        </p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/home/templates/home/modal.html
+++ b/home/templates/home/modal.html
@@ -9,6 +9,7 @@
             </div>
             <form method="post">
                 {% csrf_token %}
+                {% if invite_link %}
                 <div class="modal-body">
                     <p class="font-weight-light">
                         The Penny University community hangs out in Slack.
@@ -24,6 +25,28 @@
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                     <button type="submit" class="btn btn-primary">Join Penny University</button>
                 </div>
+                {% else %}
+                <div class="modal-body">
+                    <p class="font-weight-light">
+                        Give us your email address and we will add you to our Slack group.
+                        You will also be able to add your own Penny Chat Reviews to our Google Forum.
+                    </p>
+                    {% for field in form %}
+                        <div class="form-group">
+                            {{ field.errors }}
+                            {{ field.label_tag }}
+                            {{ field }}
+                            {% if field.help_text %}
+                                <small class="form-text text-muted">{{ field.help_text|safe }}</small>
+                            {% endif %}
+                        </div>
+                    {% endfor %}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-primary">Submit</button>
+                </div>
+                {% endif %}
             </form>
         </div>
     </div>

--- a/home/views.py
+++ b/home/views.py
@@ -13,6 +13,8 @@ def index(request):
     # if this is a POST request we need to process the form data
     if request.method == 'POST':
         if settings.SLACK_INVITE_LINK:
+            message = f'Somebody clicked join.'
+            notify_admins(slack_client, message)
             return HttpResponseRedirect(settings.SLACK_INVITE_LINK)
         else:
             # create a form instance and populate it with data from the request:

--- a/home/views.py
+++ b/home/views.py
@@ -3,21 +3,36 @@ from django.conf import settings
 from .forms import InviteForm
 import slack
 
+from bot.utils import notify_admins
 
 # Create your views here.
 slack_client = slack.WebClient(token=settings.SLACK_API_KEY)
 
 
 def index(request):
-    # if this is a POST request take user to Slack invite link
+    # if this is a POST request we need to process the form data
     if request.method == 'POST':
-        return HttpResponseRedirect(settings.SLACK_INVITE_LINK)
+        if settings.SLACK_INVITE_LINK:
+            return HttpResponseRedirect(settings.SLACK_INVITE_LINK)
+        else:
+            # create a form instance and populate it with data from the request:
+            form = InviteForm(request.POST)
+            # check whether it's valid:
+            if form.is_valid():
+                # process the data in form.cleaned_data as required
+                # send John and Nick a slack message with the person's information
+                email = form.cleaned_data["email"]
+                found_us = form.cleaned_data["how_did_you_find_us"]
+                message = f'Somebody just submitted a form!\nEmail: {email}\nHow They Found Us: {found_us}'
+                notify_admins(slack_client, message)
+                # redirect to a new URL:
+                return HttpResponseRedirect('/thank-you/')
 
     # if a GET (or any other method) we'll create a blank form
     else:
         form = InviteForm()
 
-    return render(request, 'home/index.html', {'form': form})
+    return render(request, 'home/index.html', {'form': form, 'invite_link': settings.SLACK_INVITE_LINK})
 
 
 def thank_you(request):

--- a/home/views.py
+++ b/home/views.py
@@ -29,7 +29,7 @@ def index(request):
     else:
         form = InviteForm()
 
-    return render(request, 'home/index.html', {'form': form})
+    return render(request, 'home/index.html', {'form': form, 'invite_link': settings.SLACK_INVITE_LINK})
 
 
 def thank_you(request):

--- a/home/views.py
+++ b/home/views.py
@@ -3,33 +3,21 @@ from django.conf import settings
 from .forms import InviteForm
 import slack
 
-from bot.utils import notify_admins
 
 # Create your views here.
 slack_client = slack.WebClient(token=settings.SLACK_API_KEY)
 
 
 def index(request):
-    # if this is a POST request we need to process the form data
+    # if this is a POST request take user to Slack invite link
     if request.method == 'POST':
-        # create a form instance and populate it with data from the request:
-        form = InviteForm(request.POST)
-        # check whether it's valid:
-        if form.is_valid():
-            # process the data in form.cleaned_data as required
-            # send John and Nick a slack message with the person's information
-            email = form.cleaned_data["email"]
-            found_us = form.cleaned_data["how_did_you_find_us"]
-            message = f'Somebody just submitted a form!\nEmail: {email}\nHow They Found Us: {found_us}'
-            notify_admins(slack_client, message)
-            # redirect to a new URL:
-            return HttpResponseRedirect('/thank-you/')
+        return HttpResponseRedirect(settings.SLACK_INVITE_LINK)
 
     # if a GET (or any other method) we'll create a blank form
     else:
         form = InviteForm()
 
-    return render(request, 'home/index.html', {'form': form, 'invite_link': settings.SLACK_INVITE_LINK})
+    return render(request, 'home/index.html', {'form': form})
 
 
 def thank_you(request):

--- a/penny_university/settings/base.py
+++ b/penny_university/settings/base.py
@@ -154,6 +154,10 @@ PENNY_ADMIN_USERS = ['@JB', '@nick.chouard']
 
 SLACK_TEAM_ID = 'T41DZFW4T'
 
+SLACK_INVITE_LINK = os.environ.get('SLACK_INVITE_LINK')
+if SLACK_INVITE_LINK is None:
+    print('WARNING: SLACK_INVITE_LINK is None')
+
 
 # Django Rest Framework
 REST_FRAMEWORK = {


### PR DESCRIPTION
## What

* Changed the behavior of "Join Us on Slack" button
  - If `SLACK_INVITE_LINK` is not set, then keep the current modal
  - If set, then user sees the following modal where the button takes user directly to Slack sign-up page.
![image](https://user-images.githubusercontent.com/21176245/81370704-d08ac800-90c3-11ea-9cde-f17f71539cd6.png)

* This requires `SLACK_INVITE_LINK` to be set in Heroku Config Vars!!

## Why

Simplify the signup process for both users and admins

## Reference

How to make a permanent Slack invite link: https://youtu.be/C5HAA8O_jZ8

Feel free to test the new behavior here: https://my-fake-penny1.herokuapp.com/

Closes #39 
