### PR TITLE
remove extra "success" line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,6 @@ jobs:
         run: |
           echo "NOTE: this isn't going to work once the db gets too large, but while we can take advantage of this extra safety, why not?"
           heroku pg:backups:capture -a penny-university || ./script/message_to_slack "${{ secrets.SLACK_API_KEY }}" "DEPLOY FAILED" 1
-          ./script/message_to_slack "${{ secrets.SLACK_API_KEY }}" "SUCCESSFUL DEPLOY"
       - name: Push
         if: github.event_name == 'push'
         run: |


### PR DESCRIPTION
I was sending a "successful deploy" message to slack upon successful db backup