### PR TITLE
Edit User Details

### DIFF
--- a/common/permissions.py
+++ b/common/permissions.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from rest_framework.exceptions import NotAuthenticated
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.permissions import BasePermission
 
 
@@ -39,6 +39,23 @@ def method_is_authenticated(func):
         request = args[1]
         if not request.auth:
             raise NotAuthenticated
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def method_user_is_self(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        """
+        Checks whether the object being accessed is the authenticated user.
+        If not, it raises a PermissionDenied exception.
+        This decorator is meant to be used when writing HTTP methods for APIViews, such as get() and put().
+        """
+        user = args[0].get_object()
+        request = args[1]
+        if not request.user == user:
+            raise PermissionDenied
         return func(*args, **kwargs)
 
     return wrapper

--- a/pennychat/serializers.py
+++ b/pennychat/serializers.py
@@ -5,7 +5,7 @@ from pennychat.models import (
     FollowUp,
     Participant,
 )
-from users.serializers import UserSerializer
+from users.serializers import UserDetailSerializer
 
 
 class ChoiceField(Field):
@@ -31,7 +31,7 @@ class ChoiceField(Field):
 
 
 class ParticipantSerializer(serializers.ModelSerializer):
-    user = UserSerializer(read_only=True)
+    user = UserDetailSerializer(read_only=True)
     role = ChoiceField(choices=Participant.ROLE_CHOICES)
 
     class Meta:
@@ -66,7 +66,7 @@ class FollowUpSerializer(serializers.HyperlinkedModelSerializer):
         queryset=PennyChat.objects.all(),
         view_name='pennychat-detail'
     )
-    user = UserSerializer(read_only=True)
+    user = UserDetailSerializer(read_only=True)
 
     class Meta:
         model = FollowUp

--- a/pennychat/tests/api/test_penny_chat.py
+++ b/pennychat/tests/api/test_penny_chat.py
@@ -21,7 +21,7 @@ def test_penny_chat_list(test_chats_1):
     # first chat should be most recent chat
     assert 'participants' in response.data['results'][0]
     assert response.data['results'][0]['participants'][0]['role'] == 'Organizer'
-    assert response.data['results'][0]['participants'][0]['user']['id'] == 3
+    assert response.data['results'][0]['participants'][0]['user']['id'] == most_recent_chat.get_organizer().id
     assert chats[0]['title'] == most_recent_chat.title
 
 
@@ -45,7 +45,7 @@ def test_penny_chat_detail(test_chats_1):
     assert response.status_code == 200
     assert 'participants' in response.data
     assert response.data['participants'][0]['role'] == 'Organizer'
-    assert response.data['participants'][0]['user']['id'] == 1
+    assert response.data['participants'][0]['user']['id'] == penny_chat.get_organizer().id
     assert response.data['title'] == penny_chat.title
 
 

--- a/pennychat/tests/api/test_penny_chat.py
+++ b/pennychat/tests/api/test_penny_chat.py
@@ -21,7 +21,7 @@ def test_penny_chat_list(test_chats_1):
     # first chat should be most recent chat
     assert 'participants' in response.data['results'][0]
     assert response.data['results'][0]['participants'][0]['role'] == 'Organizer'
-    assert response.data['results'][0]['participants'][0]['user']['email'] == 'three@wherever.com'
+    assert response.data['results'][0]['participants'][0]['user']['id'] == 3
     assert chats[0]['title'] == most_recent_chat.title
 
 
@@ -45,7 +45,7 @@ def test_penny_chat_detail(test_chats_1):
     assert response.status_code == 200
     assert 'participants' in response.data
     assert response.data['participants'][0]['role'] == 'Organizer'
-    assert response.data['participants'][0]['user']['email'] == 'one@wherever.com'
+    assert response.data['participants'][0]['user']['id'] == 1
     assert response.data['title'] == penny_chat.title
 
 

--- a/pennychat/tests/api/test_user_chat.py
+++ b/pennychat/tests/api/test_user_chat.py
@@ -8,10 +8,6 @@ from users.models import User
 def test_user_chats(test_chats_1):
     user = User.objects.get(username='one@wherever.com')
 
-    response = APIClient().get(f'/api/users/{user.id}/')
-    assert 'url' in response.data
-    assert response.data['chats'] == f'http://testserver/api/users/{user.id}/chats/'
-
     response = APIClient().get(f'http://testserver/api/users/{user.id}/chats/')
     assert 'results' in response.data
     assert response.data['results'][0]['penny_chat'] == f'http://testserver/api/chats/{test_chats_1[0].id}/'

--- a/pennychat/views.py
+++ b/pennychat/views.py
@@ -8,7 +8,7 @@ from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
 
 from .models import PennyChat, FollowUp, Participant
 from .serializers import PennyChatSerializer, FollowUpSerializer
-from .permissions import IsOwner, method_is_authenticated, perform_is_authenticated
+from common.permissions import IsOwner, method_is_authenticated, perform_is_authenticated
 from django_filters.rest_framework import DjangoFilterBackend
 
 logger = logging.getLogger(__name__)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -10,16 +10,15 @@ class SocialProfileSerializer(serializers.ModelSerializer):
         fields = ['id', 'real_name', 'slack_team_id']
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class RegisterUserSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(required=True)
     password = serializers.CharField(required=True, write_only=True)
     first_name = serializers.CharField()
     last_name = serializers.CharField()
-    chats = serializers.HyperlinkedIdentityField(view_name='user-chat-list')
 
     class Meta:
         model = User
-        fields = ['id', 'url', 'email', 'password', 'first_name', 'last_name', 'chats']
+        fields = ['id', 'email', 'password', 'first_name', 'last_name']
 
     def create(self, validated_data):
         user = User.objects.create_user(
@@ -32,6 +31,15 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         )
 
         return user
+
+
+class UserDetailSerializer(serializers.HyperlinkedModelSerializer):
+    first_name = serializers.CharField()
+    last_name = serializers.CharField()
+
+    class Meta:
+        model = User
+        fields = ['id', 'url', 'first_name', 'last_name']
 
 
 class CustomLoginSerializer(serializers.Serializer):

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -19,4 +19,6 @@ def test_user():
         username='test@profile.com',
         email='test@profile.com',
         password='password',
+        first_name='test',
+        last_name='user',
     )


### PR DESCRIPTION
# Description
Provides an endpoint to update the user's first and last name, and eventually more fields. closes #234 

## Details
* The user's first and last name can now be updated via a `PUT` or `PATCH` request to `users/{id}`. 
* The user serializer was split into a RegisterUserSerializer and a UserDetailSerializer so that the UserDetailSerializer would only return the relevant fields.