### PR TITLE
fix Empty chats invitations are sent. #250

### DIFF
--- a/bot/processors/pennychat.py
+++ b/bot/processors/pennychat.py
@@ -291,12 +291,13 @@ class PennyChatBotModule(BotModule):
         view = event['view']
         penny_chat_invitation = PennyChatSlackInvitation.objects.get(view=view['id'])
         state = view['state']['values']
-        penny_chat_invitation.title = state['penny_chat_title']['penny_chat_title']['value']
-        penny_chat_invitation.description = state['penny_chat_description']['penny_chat_description']['value']
 
         if event['type'] == VIEW_CLOSED:
-            penny_chat_invitation.save()
+            # note, if it's a view_closed event then we don't get updated title or description, so no need to save
             return
+
+        penny_chat_invitation.title = state['penny_chat_title']['penny_chat_title']['value']
+        penny_chat_invitation.description = state['penny_chat_description']['penny_chat_description']['value']
 
         if len(penny_chat_invitation.invitees.strip()) == 0 and len(penny_chat_invitation.channels.strip()) == 0:
             penny_chat_invitation.save()

--- a/bot/tests/processors/test_pennychat.py
+++ b/bot/tests/processors/test_pennychat.py
@@ -143,7 +143,7 @@ def test_PennyChatBotModule_share(mocker):
         },
         'actions': [{'action_id': penny_chat_constants.PENNY_CHAT_SHARE}],
         'response_url': 'http://some_website.com',
-        'type': penny_chat_constants.VIEW_SUBMISSION,
+        'type': penny_chat_constants.VIEW_CLOSED,
         'callback_id': penny_chat_constants.PENNY_CHAT_DETAILS,
     }
 
@@ -152,8 +152,16 @@ def test_PennyChatBotModule_share(mocker):
         'bot.processors.pennychat.post_organizer_edit_after_share_blocks'
     )
 
-    # The Actual Test
+    # The Actual Test (premature close)
     with mocker.patch('pennychat.models.get_or_create_social_profile_from_slack_id', side_effect=id_mock),\
+            post_organizer_edit_after_share_blocks:
+        PennyChatBotModule(mocker.Mock()).submit_details_and_share(event)
+
+    assert share_penny_chat_invitation.call_count == 0
+
+    # The Actual Test (actual submission)
+    event['type'] = penny_chat_constants.VIEW_SUBMISSION
+    with mocker.patch('pennychat.models.get_or_create_social_profile_from_slack_id', side_effect=id_mock), \
             post_organizer_edit_after_share_blocks:
         PennyChatBotModule(mocker.Mock()).submit_details_and_share(event)
 

--- a/penny_university/settings/dev.py
+++ b/penny_university/settings/dev.py
@@ -7,6 +7,6 @@ DEBUG = True
 
 # If set to True, this ensures that any background tasks are run immediately rather than using django_background_tasks
 TASK_ALWAYS_EAGER = os.environ.get('TASK_ALWAYS_EAGER', 'FALSE') == 'TRUE'
-LOG_FOR_INTEGRATION = True
+LOG_FOR_INTEGRATION = False
 
 FRONT_END_HOST = os.getenv('FRONT_END_HOST', 'http://localhost:3000')

--- a/penny_university/settings/qa.py
+++ b/penny_university/settings/qa.py
@@ -1,6 +1,7 @@
+import os
 from penny_university.settings.base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-LOG_FOR_INTEGRATION = True
+LOG_FOR_INTEGRATION = os.environ.get('LOG_FOR_INTEGRATION', 'FALSE') == 'TRUE'


### PR DESCRIPTION
# what
closes #250 by returning _before_ sending notifications if the event type is VIEW_CLOSED

I also made `LOG_FOR_INTEGRATION` optional for qa and false for dev

# why
b/c #250 - we were showing people blank Penny Chats if a user decided to quit editing a form. This would be potentially embarrassing to the user.