### PR TITLE
Remove incorrect type

### DIFF
--- a/penny_university_frontend/src/actions/user.ts
+++ b/penny_university_frontend/src/actions/user.ts
@@ -45,7 +45,7 @@ export const setToken = (token: string): AnyAction => ({
   payload: token,
 })
 
-export const bootstrap: object = (): AnyAction => ({
+export const bootstrap = (): AnyAction => ({
   type: Actions.BOOTSTRAP,
 })
 


### PR DESCRIPTION
The bootstrap variable type was being overloaded to an object making it uncallable. I removed the type and the program was able to compile.