### PR TITLE
added Build Frontend to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,3 +79,12 @@ jobs:
       working-directory: ./penny_university_frontend
       run: |
         npm run lint
+    - name: Build Frontend
+      # this broke deployment once, so better check
+      working-directory: ./penny_university_frontend
+      env:
+        CI: false
+        REACT_APP_API_ROOT: "/api/"
+      run: |
+        npm install
+        npm run build


### PR DESCRIPTION
# what 
added Build Frontend to the test workflow just like in the deploy

If I base this off of the FAQ build that was known to break then `test-frontend` breaks. https://github.com/penny-university/penny_university/pull/292/checks?check_run_id=871723661 .

If I base this off of master after Corey's fix then it passes https://github.com/penny-university/penny_university/pull/292/checks?check_run_id=871738903

# why
because this broke deployment and we don't want that 