### PR TITLE
Display error string on single line

### DIFF
--- a/penny_university_frontend/src/components/alerts/index.tsx
+++ b/penny_university_frontend/src/components/alerts/index.tsx
@@ -22,8 +22,8 @@ export const ErrorAlert = ({ error, dismiss }: AlertProps) => {
     <div className="alert-container">
       <Alert color="danger" isOpen toggle={onDismiss}>
         {
-          typeof error === "string" ? <p className="mb-0">{error}</p> :
-            Object.values(error).flat().map((v, i) => <p key={`ErrorMessage-${v}`} className="mb-0">{v}</p>)
+          typeof error === 'string' ? <p className="mb-0">{error}</p>
+            : Object.values(error).flat().map((v, i) => <p key={`ErrorMessage-${v}`} className="mb-0">{v}</p>)
         }
       </Alert>
     </div>

--- a/penny_university_frontend/src/components/alerts/index.tsx
+++ b/penny_university_frontend/src/components/alerts/index.tsx
@@ -9,7 +9,7 @@ import { RootState } from '../../reducers'
 require('./style.scss')
 
 type AlertProps = {
-  error: Object | undefined,
+  error: Object | string | undefined,
   dismiss: () => void,
 }
 
@@ -21,7 +21,10 @@ export const ErrorAlert = ({ error, dismiss }: AlertProps) => {
   return error ? (
     <div className="alert-container">
       <Alert color="danger" isOpen toggle={onDismiss}>
-        {Object.values(error).flat().map((v, i) => <p key={`ErrorMessage-${v}`} className="mb-0">{v}</p>)}
+        {
+          typeof error === "string" ? <p className="mb-0">{error}</p> :
+            Object.values(error).flat().map((v, i) => <p key={`ErrorMessage-${v}`} className="mb-0">{v}</p>)
+        }
       </Alert>
     </div>
   ) : null


### PR DESCRIPTION
# Description
Closes #306, fixing ugly error display when the value is not an object.

## Details
**Before**
<img width="1137" alt="before" src="https://user-images.githubusercontent.com/31971995/87968320-78861f80-ca7d-11ea-8391-0f07a0cfb987.png">

**After**
<img width="1151" alt="after" src="https://user-images.githubusercontent.com/31971995/87967936-de25dc00-ca7c-11ea-975f-5dc5e29faf5a.png">
