### PR TITLE
Add link to go back to chats page

### DIFF
--- a/penny_university_frontend/src/pages/Verify.tsx
+++ b/penny_university_frontend/src/pages/Verify.tsx
@@ -2,10 +2,12 @@ import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import { ThunkDispatch } from 'redux-thunk'
 import { AnyAction } from 'redux'
-import { RouteComponentProps } from 'react-router-dom'
+import { RouteComponentProps, Link } from 'react-router-dom'
 import queryString from 'query-string'
 import { RootState } from '../reducers'
 import { verifyEmail } from '../actions/user'
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faChevronLeft} from "@fortawesome/free-solid-svg-icons";
 
 type StateProps = {
   error: string | null,
@@ -28,6 +30,7 @@ const VerifyPage = ({ verify, location, error }: VerifyPageProps) => {
   return (
     <div>
       <h1 className="text-center">{message}</h1>
+      <h4 className="mt-4 text-center"><Link to='/chats'><FontAwesomeIcon icon={faChevronLeft} /> Go Back to Chats</Link></h4>
     </div>
   )
 }

--- a/penny_university_frontend/src/pages/Verify.tsx
+++ b/penny_university_frontend/src/pages/Verify.tsx
@@ -4,10 +4,10 @@ import { ThunkDispatch } from 'redux-thunk'
 import { AnyAction } from 'redux'
 import { RouteComponentProps, Link } from 'react-router-dom'
 import queryString from 'query-string'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { RootState } from '../reducers'
 import { verifyEmail } from '../actions/user'
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faChevronLeft} from "@fortawesome/free-solid-svg-icons";
 
 type StateProps = {
   error: string | null,
@@ -31,7 +31,13 @@ const VerifyPage = ({ verify, location, error }: VerifyPageProps) => {
   return (
     <div>
       <h1 className="text-center">{message}</h1>
-      <h4 className="mt-4 text-center"><Link to='/chats'><FontAwesomeIcon icon={faChevronLeft} /> Go Back to Chats</Link></h4>
+      <h4 className="mt-4 text-center">
+        <Link to="/chats">
+          <FontAwesomeIcon icon={faChevronLeft} />
+          {' '}
+          Go Back to Chats
+        </Link>
+      </h4>
     </div>
   )
 }


### PR DESCRIPTION
# Description
Closes #309, providing a way for users to return to the chats page after verifying their email and logging in.

## Details
**Verification screen**
<img width="1183" alt="verify" src="https://user-images.githubusercontent.com/31971995/88236620-a95f8380-cc3a-11ea-91b7-4ee6345c97f9.png">
