### PR TITLE
Add participants list to chat detail

### DIFF
--- a/penny_university_frontend/src/components/chats/ChatCard.tsx
+++ b/penny_university_frontend/src/components/chats/ChatCard.tsx
@@ -8,17 +8,18 @@ import {
 import Date from '../Date'
 import { Content } from '../content'
 import ParticipantList from './ParticipantList'
-import { Chat } from '../../models'
+import { Chat, User } from '../../models'
 
 export const TestIDs = {
   chatCard: 'chart-card',
 }
 
 type ChatCardProps = {
-  chat: Chat | undefined
+  chat: Chat | undefined,
+  getUserByID: (id: number) => User,
 }
 
-const ChatCard = ({ chat }: ChatCardProps) => (chat ? (
+const ChatCard = ({ chat, getUserByID }: ChatCardProps) => (chat ? (
   <Card body className="mb-3 border-0 shadow-sm" data-testid={TestIDs.chatCard}>
     <CardTitle tag="h5">
       <Link className="text-reset" to={`/chats/${chat.id}`}>{chat.title}</Link>
@@ -28,7 +29,7 @@ const ChatCard = ({ chat }: ChatCardProps) => (chat ? (
     {chat.description
       ? <Content content={chat.description} /> : null}
     <div className="d-flex">
-      <ParticipantList className="mr-2" participants={chat.participants} chatID={chat.id} />
+      <ParticipantList className="mr-2" participants={chat.participants} chatID={chat.id} getUserByID={getUserByID} />
       -
       <Link className="ml-2" to={`/chats/${chat.id}`}>
         {chat.followUpsCount}

--- a/penny_university_frontend/src/components/chats/ChatDetail.tsx
+++ b/penny_university_frontend/src/components/chats/ChatDetail.tsx
@@ -9,6 +9,7 @@ import { FollowUpCard } from '../follow-ups'
 import modalDispatch from '../modal/dispatch'
 import { Chat, FollowUp, User } from '../../models'
 import { FollowUpType } from '../../models/followUp'
+import ParticipantList from './ParticipantList'
 
 require('./styles.scss')
 
@@ -61,11 +62,15 @@ const ChatDetail = ({
         <div className="mb-4">
           <CreateButton type="Follow Up" onClick={createOnPress} />
         </div>
-        <h5 className="mb-3">
-          {followUps.length}
-          {' '}
-          Follow Ups
-        </h5>
+        <div className="d-flex">
+          <ParticipantList className="mr-2 h5" participants={chat.participants} chatID={chat.id} getUserByID={getUserByID} />
+          <h5>-</h5>
+          <h5 className="mb-3 ml-2">
+            {followUps.length}
+            {' '}
+            Follow Ups
+          </h5>
+        </div>
         {followUps.map((followUp) => {
           const followUpUser = getUserByID(followUp.user)
           const role = chat.getUserRole(followUp.user)

--- a/penny_university_frontend/src/components/chats/ChatList.tsx
+++ b/penny_university_frontend/src/components/chats/ChatList.tsx
@@ -8,12 +8,13 @@ import { loadChatsList } from '../../actions/chat'
 import { RootState } from '../../reducers'
 import * as selectors from '../../selectors'
 import ChatCard from './ChatCard'
-import { Chat } from '../../models'
+import { Chat, User } from '../../models'
 
 type StateProps = {
   nextPageUrl: string,
   chats: Array<number>,
   getChatByID: (id: number) => Chat,
+  getUserByID: (id: number) => User,
   isFetching: boolean,
 }
 
@@ -28,7 +29,7 @@ type OwnProps = {
 type ChatListProps = StateProps & DispatchProps & OwnProps & RouteComponentProps<{}>
 
 const ChatList = ({
-  chats, getChatByID, nextPageUrl, isFetching, loadChatsList, filter,
+  chats, getChatByID, getUserByID, nextPageUrl, isFetching, loadChatsList, filter,
 }: ChatListProps) => {
   const loadMore = () => {
     if (!isFetching) {
@@ -45,7 +46,7 @@ const ChatList = ({
         threshold={200}
       >
         {chats.map((chatID: number) => (
-          <ChatCard chat={getChatByID(chatID)} key={`ChatCard-${chatID}`} />))}
+          <ChatCard chat={getChatByID(chatID)} key={`ChatCard-${chatID}`} getUserByID={getUserByID} />))}
       </InfiniteScroll>
     </div>
   )
@@ -58,6 +59,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
     chats: chatsPagination.ids,
     nextPageUrl,
     getChatByID: (id: number) => selectors.chats.getChatByID(state, id),
+    getUserByID: (id: string) => selectors.entities.getUserByID(state, id),
     isFetching: selectors.pagination.isFetchingChats(state, ownProps.filter.key),
   }
 }

--- a/penny_university_frontend/src/components/chats/ParticipantList.tsx
+++ b/penny_university_frontend/src/components/chats/ParticipantList.tsx
@@ -1,9 +1,6 @@
 import React, { useState } from 'react'
-import { connect } from 'react-redux'
 import { Popover, PopoverHeader, PopoverBody } from 'reactstrap'
 import { Link } from 'react-router-dom'
-import * as selectors from '../../selectors'
-import { RootState } from '../../reducers'
 import User from '../../models/user'
 
 type ParticipantListProps = {
@@ -61,8 +58,4 @@ const ParticipantList = ({
   )
 }
 
-const mapStateToProps = (state: RootState) => ({
-  getUserByID: (id: string) => selectors.entities.getUserByID(state, id),
-})
-// @ts-ignore
-export default connect(mapStateToProps)(ParticipantList)
+export default ParticipantList


### PR DESCRIPTION
# Description
Closes #289. Adds the participants list that is on the Chat Card to the Chat Detail as well.

## Details
You can now view who participated in chats from the Chat Detail. You can hover over the participants to view the list, like in the Chat Card.
<img width="924" alt="Screen Shot 2020-07-23 at 4 27 21 PM" src="https://user-images.githubusercontent.com/31971995/88345128-8b5d5600-cd02-11ea-8fdd-5965cf45bb51.png">
<img width="929" alt="Screen Shot 2020-07-23 at 4 27 30 PM" src="https://user-images.githubusercontent.com/31971995/88345133-8dbfb000-cd02-11ea-9b44-1d15d1e6fc96.png">
