### PR TITLE
Fixing issue of squared follow-ups value

### DIFF
--- a/pennychat/views.py
+++ b/pennychat/views.py
@@ -39,7 +39,7 @@ class PennyChatViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows penny chats to be viewed or edited.
     """
-    queryset = PennyChat.objects.annotate(follow_ups_count=Count('follow_ups')).order_by('-date')
+    queryset = PennyChat.objects.annotate(follow_ups_count=Count('follow_ups', distinct=True)).order_by('-date')
     serializer_class = PennyChatSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = PennyChatFilter


### PR DESCRIPTION
# What

Fixes #285 which caused followUps to be ran twice and provide an incorrect value.

# Why

To display the correct number at all times.

## Note

This fix of adding `distinct=True` that Adam gave me seems to work perfectly, but my original finding of ChatCard and ChatDetails using two different values should probably be fixed eventually. Only issue is that I haven't been able to find a way to get ChatList to grab the list of follow ups.