### PR TITLE
Merge Users

### DIFF
--- a/docs/product_catalog.md
+++ b/docs/product_catalog.md
@@ -18,6 +18,7 @@ The goal of this document is to enumerate all the pieces so that we don't lose t
 * Internal API (see api directory)
 * Importing data from forum (pennychat/management/commands/import_google_forum.py)
 * Importing users from Slack (users/management/commands/import_users_from_slack.py)
+* Email Penny University members (users/management/commands/email_members.py)
 * Merge two users using their email (users/management/commands/merge_users.py)
 
 ## Other

--- a/docs/product_catalog.md
+++ b/docs/product_catalog.md
@@ -18,6 +18,7 @@ The goal of this document is to enumerate all the pieces so that we don't lose t
 * Internal API (see api directory)
 * Importing data from forum (pennychat/management/commands/import_google_forum.py)
 * Importing users from Slack (users/management/commands/import_users_from_slack.py)
+* Merge two users using their email (users/management/commands/merge_users.py)
 
 ## Other
 * Bot framework (bot/processors/base.py) This was used to build the greeting and pennychat processors. This file should be treated as if it's a vendored import. Don't include Penny University specific things back in it.

--- a/users/management/commands/merge_users.py
+++ b/users/management/commands/merge_users.py
@@ -1,0 +1,69 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from sentry_sdk import capture_exception
+
+from pennychat.models import Participant, FollowUp
+from users.models import User, SocialProfile
+
+
+class Command(BaseCommand):
+    help = (
+        'Merge two users into one.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--live-run',
+            dest='live_run',
+            action='store_true',
+            help='opposite of dry run - will actually write data to the database',
+            required=False,
+        )
+        parser.add_argument(
+            '--from-email',
+            dest='from_email',
+            help='The email of the user you want to merge into the other',
+            required=True,
+        )
+        parser.add_argument(
+            '--to-email',
+            dest='to_email',
+            help='The email of the user you want to merge into',
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        try:
+            with transaction.atomic():
+                from_user = User.objects.get(email=options['from_email'])
+                to_user = User.objects.get(email=options['to_email'])
+                merge_users(from_user, to_user)
+                if not options['live_run']:
+                    print('THIS IS A DRY RUN ONLY - NOT COMMITTING')
+                    print('Run with --live_run to actually commit.')
+                    raise RuntimeError('not committing')
+                print('COMMITTED')
+        except Exception as e:
+            capture_exception(e)
+            if str(e) == 'not committing':
+                pass
+            else:
+                raise
+
+
+def merge_users(from_user, to_user):
+    participants = Participant.objects.filter(user=from_user)
+    for participant in participants:
+        participant.user = to_user
+        participant.save()
+        print(f'Participation in "{participant.penny_chat.title}" merged to {to_user.email}')
+    follow_ups = FollowUp.objects.filter(user=from_user)
+    for follow_up in follow_ups:
+        follow_up.user = to_user
+        follow_up.save()
+        print(f'Follow Up from "{follow_up.penny_chat.title}" merged to {to_user.email}')
+    profiles = SocialProfile.objects.filter(user=from_user)
+    for profile in profiles:
+        profile.user = to_user
+        profile.save()
+        print(f'Profile {profile.email} merged to {to_user.email}')

--- a/users/management/commands/merge_users.py
+++ b/users/management/commands/merge_users.py
@@ -2,8 +2,8 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from sentry_sdk import capture_exception
 
-from pennychat.models import Participant, FollowUp
-from users.models import User, SocialProfile
+from users.utils import merge_users
+from users.models import User
 
 
 class Command(BaseCommand):
@@ -40,7 +40,7 @@ class Command(BaseCommand):
                 merge_users(from_user, to_user)
                 if not options['live_run']:
                     print('THIS IS A DRY RUN ONLY - NOT COMMITTING')
-                    print('Run with --live_run to actually commit.')
+                    print('Run with --live-run to actually commit.')
                     raise RuntimeError('not committing')
                 print('COMMITTED')
         except Exception as e:
@@ -49,21 +49,3 @@ class Command(BaseCommand):
                 pass
             else:
                 raise
-
-
-def merge_users(from_user, to_user):
-    participants = Participant.objects.filter(user=from_user)
-    for participant in participants:
-        participant.user = to_user
-        participant.save()
-        print(f'Participation in "{participant.penny_chat.title}" merged to {to_user.email}')
-    follow_ups = FollowUp.objects.filter(user=from_user)
-    for follow_up in follow_ups:
-        follow_up.user = to_user
-        follow_up.save()
-        print(f'Follow Up from "{follow_up.penny_chat.title}" merged to {to_user.email}')
-    profiles = SocialProfile.objects.filter(user=from_user)
-    for profile in profiles:
-        profile.user = to_user
-        profile.save()
-        print(f'Profile {profile.email} merged to {to_user.email}')

--- a/users/management/commands/merge_users.py
+++ b/users/management/commands/merge_users.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--from-email',
             dest='from_email',
-            help='The email of the user you want to merge into the other',
+            help='The email of the user you want to merge into the other. This user will be deleted',
             required=True,
         )
         parser.add_argument(

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,0 +1,20 @@
+from pennychat.models import Participant, FollowUp
+from users.models import SocialProfile
+
+
+def merge_users(from_user, to_user):
+    participants = Participant.objects.filter(user=from_user)
+    for participant in participants:
+        participant.user = to_user
+        participant.save()
+        print(f'Participation in "{participant.penny_chat.title}" merged to {to_user.email}')
+    follow_ups = FollowUp.objects.filter(user=from_user)
+    for follow_up in follow_ups:
+        follow_up.user = to_user
+        follow_up.save()
+        print(f'Follow Up from "{follow_up.penny_chat.title}" merged to {to_user.email}')
+    profiles = SocialProfile.objects.filter(user=from_user)
+    for profile in profiles:
+        profile.user = to_user
+        profile.save()
+        print(f'Profile {profile.email} merged to {to_user.email}')


### PR DESCRIPTION
# Description
We have a couple of users who have two different emails for Penny U. They could have Follow Ups from the forum that are not associated with the account they've created for our platform. This changes introduces a management function that merges two users based on their emails.

## Details
To show proof of completeness, I created a user named Mr Merge. He had a Social Profile and created a Penny Chat and Follow Up.
<img width="1315" alt="before" src="https://user-images.githubusercontent.com/31971995/89350936-973c0700-d676-11ea-9665-4280dd3dde9e.png">
Running this command, `python manage.py merge_users --from-email haxiwe1494@cartmails.com --to-email nick.chouard@gmail.com`, produces this output:
```
WARNING: SLACK_INVITE_LINK is None
Participation in "A Chat by Mr Merge" merged to nick.chouard@gmail.com
Follow Up from "A Chat by Mr Merge" merged to nick.chouard@gmail.com
Profile Mr Merge merged to nick.chouard@gmail.com
THIS IS A DRY RUN ONLY - NOT COMMITTING
Run with --live-run to actually commit.
```
After running the command with the `--live-run` flag, this is the output:
<img width="1315" alt="after" src="https://user-images.githubusercontent.com/31971995/89351246-3bbe4900-d677-11ea-94f8-566b30de9176.png">
All of Mr. Merge's assets now belong to Nick Chouard.
