### PR TITLE
Replace Instagram link with YouTube

### DIFF
--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -36,7 +36,7 @@
                 <div class="social-icons">
                     <a href="https://www.facebook.com/officialpennyu" class="fa fa-facebook"></a>
                     <a href="https://twitter.com/officialpennyu" class="fa fa-twitter"></a>
-                    <a href="https://www.instagram.com/officialpennyu" class="fa fa-instagram"></a>
+                    <a href="https://www.youtube.com/channel/UCgYQSZ4GrTsdHNE2SvTQdiw" class="fa fa-youtube"></a>
                 </div>
             </div>
         </div>

--- a/penny_university/static/css/style.css
+++ b/penny_university/static/css/style.css
@@ -7198,8 +7198,8 @@ h1, h2, h3, .navbar-brand {
   background: #3b5998;
   color: #fff; }
 
-.fa-instagram {
-  background: #d30f62;
+.fa-youtube {
+  background: #c4302b;
   color: #fff; }
 
 .fa-twitter {

--- a/penny_university_frontend/scss/_main.scss
+++ b/penny_university_frontend/scss/_main.scss
@@ -76,8 +76,8 @@ h1, h2, h3, .navbar-brand {
   color: #fff;
 }
 
-.fa-instagram {
-  background: #d30f62;
+.fa-youtube {
+  background: #c4302b;
   color: #fff;
 }
 

--- a/penny_university_frontend/src/style.css
+++ b/penny_university_frontend/src/style.css
@@ -7202,8 +7202,8 @@ h1, h2, h3, .navbar-brand {
   background: #3b5998;
   color: #fff; }
 
-.fa-instagram {
-  background: #d30f62;
+.fa-youtube {
+  background: #c4302b;
   color: #fff; }
 
 .fa-twitter {


### PR DESCRIPTION
# Description
We don't have any content on Instagram, but we do have some on Youtube. This change replaces the Instagram link on our home page with a YouTube link.

<img width="1204" alt="youtube" src="https://user-images.githubusercontent.com/31971995/89356888-8f835f00-d684-11ea-98d4-54ea0e131fc4.png">
