### PR TITLE
Remove hyperlinked PennyChat, use ID instead

### DIFF
--- a/pennychat/serializers.py
+++ b/pennychat/serializers.py
@@ -62,11 +62,7 @@ class UserChatSerializer(serializers.ModelSerializer):
         fields = ['penny_chat', 'role']
 
 
-class FollowUpSerializer(serializers.HyperlinkedModelSerializer):
-    penny_chat = serializers.HyperlinkedRelatedField(
-        queryset=PennyChat.objects.all(),
-        view_name='pennychat-detail'
-    )
+class FollowUpSerializer(serializers.ModelSerializer):
     user = UserDetailSerializer(read_only=True)
 
     class Meta:

--- a/pennychat/tests/api/test_follow_up.py
+++ b/pennychat/tests/api/test_follow_up.py
@@ -63,7 +63,7 @@ def test_update_follow_up(test_chats_1):
     chat_data = client.get(f'/api/chats/{first_penny_chat.id}/').data
     data = {
         'content': 'Update follow up',
-        'penny_chat': chat_data['url'],
+        'penny_chat': chat_data['id'],
     }
     follow_up = second_penny_chat.follow_ups.first()
     response = client.put(f'/api/follow-ups/{follow_up.id}/', data=data, format='json')
@@ -85,7 +85,7 @@ def test_update_follow_up_unauthorized(test_chats_1):
     chat_data = client.get(f'/api/chats/{penny_chat.id}/').data
     data = {
         'content': 'Update follow up',
-        'penny_chat': chat_data['url'],
+        'penny_chat': chat_data['id'],
     }
     follow_up = penny_chat.follow_ups.first()
     response = client.put(f'/api/follow-ups/{follow_up.id}/', data=data, format='json')
@@ -102,7 +102,7 @@ def test_update_follow_up_wrong_user(test_chats_1):
     chat_data = client.get(f'/api/chats/{first_penny_chat.id}/').data
     data = {
         'content': 'Update follow up',
-        'penny_chat': chat_data['url'],
+        'penny_chat': chat_data['id'],
     }
     follow_up = first_penny_chat.follow_ups.first()
     response = client.put(f'/api/follow-ups/{follow_up.id}/', data=data, format='json')


### PR DESCRIPTION
# Description
Closes #324. The frontend no longer crashes when you delete follow ups.

## Details
This turned out to be a result of what we were returning from our API. Our API returns different values for when we write FollowUps and when we just fetch them. In the former we are returning ids and in the latter we return hyperlinked urls to the Penny Chat. Since the frontend expects IDs in order to update the store, this was causing issues when trying to find the Penny Chat to delete the follow up from. This change removes the hyperlink from the Follow Up to the Penny Chat model, and uses ID instead.