### PR TITLE
Protect notify_users script from missing slack ids or from long lists

### DIFF
--- a/users/management/commands/tests/test_notify_users_about_activity.py
+++ b/users/management/commands/tests/test_notify_users_about_activity.py
@@ -7,7 +7,7 @@ import pytest
 
 from common.tests.fakes import UserFactory, PennyChatFactory, FollowUpFactory, SocialProfileFactory
 from pennychat.models import Participant
-from users.management.commands.notify_users_about_activity import Command, get_recent_followup_queryset, get_range, \
+from users.management.commands.notify_users_about_activity import Command, get_recent_followup_dataset, get_range, \
     notify_about_activity, grouped, UnorderedDataError
 
 UTC = pytz.utc
@@ -21,6 +21,21 @@ before_range_date = datetime(2019, 1, 2, 0, 0, tzinfo=timezone.utc)
 
 
 def setup_followup_history():
+    """
+    There are 4 users 1,2,3,4 but 4 doesn't have a social profile
+
+    There are 2 chats:
+    * chat 1 has participants 1,2,3,4 and followups from 2 outside of time range and 3,4 within time range
+    * chat 2 has participants 1,2 and followups from 2 inside of time range
+
+    Therefore
+    * user 1 will get notifications from 3,4 for chat 1   and    from 2 for chat 2
+    * user 2 will get notifications from 3,4 for chat 1
+    * user 3 will get notifications from 4 for chat 1  <-- note: users don't receive notifications for their own updates
+    * user 4 would get notifications from 3 for chat 1 BUT has no social profile, so no way to contact them
+
+    :return:
+    """
     user1 = UserFactory()
     soc_prof1 = SocialProfileFactory(user=user1)
     user2 = UserFactory()
@@ -28,48 +43,92 @@ def setup_followup_history():
     user3 = UserFactory()
     soc_prof3 = SocialProfileFactory(user=user3)
     user4 = UserFactory()
-    soc_prof4 = SocialProfileFactory(user=user4)
+    # NOTE! soc_prof4 is intentionally omitted because sometimes a User doesn't have a SocialProfile
 
     penny_chat1 = PennyChatFactory()
     Participant.objects.create(penny_chat=penny_chat1, user=user1, role=Participant.ORGANIZER)
     Participant.objects.create(penny_chat=penny_chat1, user=user2, role=Participant.ATTENDEE)
     Participant.objects.create(penny_chat=penny_chat1, user=user3, role=Participant.ATTENDEE)
-    FollowUpFactory(penny_chat=penny_chat1, user=user1, date=before_range_date)
-    FollowUpFactory(penny_chat=penny_chat1, user=user2, date=within_range_date)
-    FollowUpFactory(penny_chat=penny_chat1, user=user2, date=within_range_date)
+    Participant.objects.create(penny_chat=penny_chat1, user=user4, role=Participant.ATTENDEE)
+    FollowUpFactory(penny_chat=penny_chat1, user=user2, date=before_range_date)
+    FollowUpFactory(penny_chat=penny_chat1, user=user3, date=within_range_date)
+    FollowUpFactory(penny_chat=penny_chat1, user=user4, date=within_range_date)
 
     penny_chat2 = PennyChatFactory()
     Participant.objects.create(penny_chat=penny_chat2, user=user2, role=Participant.ORGANIZER)
-    Participant.objects.create(penny_chat=penny_chat2, user=user3, role=Participant.ATTENDEE)
-    Participant.objects.create(penny_chat=penny_chat2, user=user4, role=Participant.ATTENDEE)
+    Participant.objects.create(penny_chat=penny_chat2, user=user1, role=Participant.ATTENDEE)
     FollowUpFactory(penny_chat=penny_chat2, user=user2, date=within_range_date)
-    FollowUpFactory(penny_chat=penny_chat2, user=user3, date=within_range_date)
-    FollowUpFactory(penny_chat=penny_chat2, user=user4, date=within_range_date)
 
     return {
         'penny_chats': [penny_chat1, penny_chat2],
         'users': [user1, user2, user3, user4],
-        'social_profiles': [soc_prof1, soc_prof2, soc_prof3, soc_prof4]
+        'social_profiles': [soc_prof1, soc_prof2, soc_prof3]
     }
 
 
 @pytest.mark.django_db
-def test_get_recent_followup_queryset(mocker):
+def test_get_recent_followup_dataset(mocker):
     objects = setup_followup_history()
     penny_chat1, penny_chat2 = objects['penny_chats']
     user1, user2, user3, user4 = objects['users']
-    soc_prof1, soc_prof2, soc_prof3, soc_prof4 = objects['social_profiles']
+    soc_prof1, soc_prof2, soc_prof3 = objects['social_profiles']
 
-    recent_followup_queryset = get_recent_followup_queryset(range_start, range_end, [user1.email, user2.email])
-    actual = [item for item in recent_followup_queryset]
+    recent_followup_dataset = list(get_recent_followup_dataset(
+        range_start,
+        range_end,
+    ))
+    for item in recent_followup_dataset:
+        assert item['id'] != item['user_chats__penny_chat__follow_ups__user_id'], 'we should not send notifications to users who made the update'  # noqa
+        assert item['social_profiles__slack_team_id'] and item['social_profiles__slack_id'], 'users w/o social profiles can\'t be contacted and should be filtered out'  # noqa
+
+    # I've split up the fields for each item into 3 rows: user-relate, chat-related, followup-related
     expected = [
-        {'id': user1.id, 'first_name': user1.first_name, 'social_profiles__slack_team_id': soc_prof1.slack_team_id, 'social_profiles__slack_id': soc_prof1.slack_id, 'user_chats__penny_chat__id': penny_chat1.id, 'user_chats__penny_chat__date': penny_chat1.date, 'user_chats__penny_chat__title': penny_chat1.title, 'user_chats__penny_chat__follow_ups__user_id': user2.id, 'user_chats__penny_chat__follow_ups__user__first_name': user2.first_name},  # noqa
-        {'id': user2.id, 'first_name': user2.first_name, 'social_profiles__slack_team_id': soc_prof2.slack_team_id, 'social_profiles__slack_id': soc_prof2.slack_id, 'user_chats__penny_chat__id': penny_chat1.id, 'user_chats__penny_chat__date': penny_chat1.date, 'user_chats__penny_chat__title': penny_chat1.title, 'user_chats__penny_chat__follow_ups__user_id': user2.id, 'user_chats__penny_chat__follow_ups__user__first_name': user2.first_name},  # noqa
-        {'id': user2.id, 'first_name': user2.first_name, 'social_profiles__slack_team_id': soc_prof2.slack_team_id, 'social_profiles__slack_id': soc_prof2.slack_id, 'user_chats__penny_chat__id': penny_chat2.id, 'user_chats__penny_chat__date': penny_chat2.date, 'user_chats__penny_chat__title': penny_chat2.title, 'user_chats__penny_chat__follow_ups__user_id': user2.id, 'user_chats__penny_chat__follow_ups__user__first_name': user2.first_name},  # noqa
-        {'id': user2.id, 'first_name': user2.first_name, 'social_profiles__slack_team_id': soc_prof2.slack_team_id, 'social_profiles__slack_id': soc_prof2.slack_id, 'user_chats__penny_chat__id': penny_chat2.id, 'user_chats__penny_chat__date': penny_chat2.date, 'user_chats__penny_chat__title': penny_chat2.title, 'user_chats__penny_chat__follow_ups__user_id': user3.id, 'user_chats__penny_chat__follow_ups__user__first_name': user3.first_name},  # noqa
-        {'id': user2.id, 'first_name': user2.first_name, 'social_profiles__slack_team_id': soc_prof2.slack_team_id, 'social_profiles__slack_id': soc_prof2.slack_id, 'user_chats__penny_chat__id': penny_chat2.id, 'user_chats__penny_chat__date': penny_chat2.date, 'user_chats__penny_chat__title': penny_chat2.title, 'user_chats__penny_chat__follow_ups__user_id': user4.id, 'user_chats__penny_chat__follow_ups__user__first_name': user4.first_name},  # noqa
+        {
+            'id': user1.id, 'first_name': user1.first_name, 'social_profiles__slack_team_id': soc_prof1.slack_team_id, 'social_profiles__slack_id': soc_prof1.slack_id,  # noqa
+            'user_chats__penny_chat__id': penny_chat1.id, 'user_chats__penny_chat__date': penny_chat1.date, 'user_chats__penny_chat__title': penny_chat1.title,  # noqa
+            'user_chats__penny_chat__follow_ups__user_id': user3.id, 'user_chats__penny_chat__follow_ups__user__first_name': user3.first_name,  # noqa
+        }, {
+            'id': user1.id, 'first_name': user1.first_name, 'social_profiles__slack_team_id': soc_prof1.slack_team_id, 'social_profiles__slack_id': soc_prof1.slack_id,  # noqa
+            'user_chats__penny_chat__id': penny_chat1.id, 'user_chats__penny_chat__date': penny_chat1.date, 'user_chats__penny_chat__title': penny_chat1.title,  # noqa
+            'user_chats__penny_chat__follow_ups__user_id': user4.id, 'user_chats__penny_chat__follow_ups__user__first_name': user4.first_name,  # noqa
+        }, {
+            'id': user1.id, 'first_name': user1.first_name, 'social_profiles__slack_team_id': soc_prof1.slack_team_id, 'social_profiles__slack_id': soc_prof1.slack_id,  # noqa
+            'user_chats__penny_chat__id': penny_chat2.id, 'user_chats__penny_chat__date': penny_chat2.date, 'user_chats__penny_chat__title': penny_chat2.title,  # noqa
+            'user_chats__penny_chat__follow_ups__user_id': user2.id, 'user_chats__penny_chat__follow_ups__user__first_name': user2.first_name,  # noqa
+        }, {
+            'id': user2.id, 'first_name': user2.first_name, 'social_profiles__slack_team_id': soc_prof2.slack_team_id, 'social_profiles__slack_id': soc_prof2.slack_id,  # noqa
+            'user_chats__penny_chat__id': penny_chat1.id, 'user_chats__penny_chat__date': penny_chat1.date, 'user_chats__penny_chat__title': penny_chat1.title,  # noqa
+            'user_chats__penny_chat__follow_ups__user_id': user3.id, 'user_chats__penny_chat__follow_ups__user__first_name': user3.first_name,  # noqa
+        }, {
+            'id': user2.id, 'first_name': user2.first_name, 'social_profiles__slack_team_id': soc_prof2.slack_team_id, 'social_profiles__slack_id': soc_prof2.slack_id,  # noqa
+            'user_chats__penny_chat__id': penny_chat1.id, 'user_chats__penny_chat__date': penny_chat1.date, 'user_chats__penny_chat__title': penny_chat1.title,  # noqa
+            'user_chats__penny_chat__follow_ups__user_id': user4.id, 'user_chats__penny_chat__follow_ups__user__first_name': user4.first_name,  # noqa
+        }, {
+            'id': user3.id, 'first_name': user3.first_name, 'social_profiles__slack_team_id': soc_prof3.slack_team_id, 'social_profiles__slack_id': soc_prof3.slack_id,  # noqa
+            'user_chats__penny_chat__id': penny_chat1.id, 'user_chats__penny_chat__date': penny_chat1.date, 'user_chats__penny_chat__title': penny_chat1.title,  # noqa
+            'user_chats__penny_chat__follow_ups__user_id': user4.id, 'user_chats__penny_chat__follow_ups__user__first_name': user4.first_name,  # noqa
+        }
     ]
-    assert actual == expected
+    assert recent_followup_dataset == expected
+
+
+@pytest.mark.django_db
+def test_get_recent_followup_dataset__filter_email(mocker):
+    objects = setup_followup_history()
+    penny_chat1, penny_chat2 = objects['penny_chats']
+    user1, user2, user3, user4 = objects['users']
+    soc_prof1, soc_prof2, soc_prof3 = objects['social_profiles']
+
+    recent_followup_dataset = get_recent_followup_dataset(
+        range_start,
+        range_end,
+        [user1.email, user2.email],
+    )
+    user_ids_being_notified = {item['id'] for item in recent_followup_dataset}
+    assert user1.id in user_ids_being_notified
+    assert user2.id in user_ids_being_notified
+    assert user3.id not in user_ids_being_notified
+    assert user4.id not in user_ids_being_notified  # this should be filtered out anyway b/c of no social id
 
 
 @pytest.mark.django_db
@@ -77,11 +136,11 @@ def test_handle(mocker):
     objects = setup_followup_history()
     penny_chat1, penny_chat2 = objects['penny_chats']
     user1, user2, user3, user4 = objects['users']
-    soc_prof1, soc_prof2, soc_prof3, soc_prof4 = objects['social_profiles']
+    soc_prof1, soc_prof2, soc_prof3 = objects['social_profiles']
 
     command = Command()
-    mock_get_recent_followup_queryset = mocker.patch('users.management.commands.notify_users_about_activity.get_recent_followup_queryset')  # noqa
-    mock_get_recent_followup_queryset.side_effect = get_recent_followup_queryset
+    mock_get_recent_followup_dataset = mocker.patch('users.management.commands.notify_users_about_activity.get_recent_followup_dataset')  # noqa
+    mock_get_recent_followup_dataset.side_effect = get_recent_followup_dataset
     notify_about_activity = mocker.patch('users.management.commands.notify_users_about_activity.notify_about_activity')
     live_run = False
     options = {
@@ -91,9 +150,9 @@ def test_handle(mocker):
         'yesterday': False,
         'filter_emails': f'{user1.email},{user2.email}',
     }
-    # NOTE: if anything breaks in get_recent_followup_queryset then fix it in test_get_recent_followup_queryset
+    # NOTE: if anything breaks in get_recent_followup_dataset then fix it in test_get_recent_followup_dataset
     command.handle(**options)
-    assert mock_get_recent_followup_queryset.call_args == call(
+    assert mock_get_recent_followup_dataset.call_args == call(
         range_start,
         range_end,
         [user1.email, user2.email],
@@ -106,17 +165,24 @@ def test_handle(mocker):
                 {
                     'id': penny_chat1.id, 'title': penny_chat1.title, 'date': penny_chat1.date,
                     'followups': [
+                        {'user_id': user3.id, 'first_name': user3.first_name},
+                        {'user_id': user4.id, 'first_name': user4.first_name},
+                    ]
+                }, {
+                    'id': penny_chat2.id, 'title': penny_chat2.title, 'date': penny_chat2.date,
+                    'followups': [
                         {'user_id': user2.id, 'first_name': user2.first_name},
                     ]
-                }
+                },
             ]},
             live_run,
         ),
         call({
-            'user_id': user2.id, 'first_name': user2.first_name, 'slack_team_id': soc_prof2.slack_team_id, 'slack_id': soc_prof2.slack_id,  # noqa
+            'user_id': user2.id, 'first_name': user2.first_name, 'slack_team_id': soc_prof2.slack_team_id,
+            'slack_id': soc_prof2.slack_id,  # noqa
             'penny_chats': [
                 {
-                    'id': penny_chat2.id, 'title': penny_chat2.title, 'date': penny_chat2.date,
+                    'id': penny_chat1.id, 'title': penny_chat1.title, 'date': penny_chat1.date,
                     'followups': [
                         {'user_id': user3.id, 'first_name': user3.first_name},
                         {'user_id': user4.id, 'first_name': user4.first_name},
@@ -125,6 +191,8 @@ def test_handle(mocker):
             ]},
             live_run,
         ),
+        # NOTE user3 id filtered out from the email filter and user4 is filtered out because they don't have a social
+        # profile
     ]
     assert actual == expected
 


### PR DESCRIPTION
# wat
[My previous PR](https://github.com/penny-university/penny_university/pull/329) would error if the user had no social profile (e.g. no slack id to contact) or if there were too many items in the blocks that we ship to Slack. This protects from those two specifically and adds a try/except for everything else (and writes to sentry)

# relates 
parent https://github.com/penny-university/penny_university/issues/300