### PR TITLE
Updated Interest Survey

### DIFF
--- a/bot/management/commands/onboard_users.py
+++ b/bot/management/commands/onboard_users.py
@@ -34,8 +34,6 @@ class Command(BaseCommand):
         }
         slack_name__user_id = {v: k for k, v in user_id__slack_name.items()}
 
-        print(slack_name__user_id)
-
         not_found_users = set()
         user_ids = set()
         if slack_names:

--- a/bot/management/commands/onboard_users.py
+++ b/bot/management/commands/onboard_users.py
@@ -34,25 +34,27 @@ class Command(BaseCommand):
         }
         slack_name__user_id = {v: k for k, v in user_id__slack_name.items()}
 
+        print(slack_name__user_id)
+
         not_found_users = set()
-        non_responded_user_ids = set()
+        user_ids = set()
         if slack_names:
             for slack_name in slack_names:
+                print(slack_name)
                 user_id = slack_name__user_id.get(slack_name)
                 if user_id:
-                    non_responded_user_ids.add(user_id)
+                    user_ids.add(user_id)
                 else:
                     not_found_users.add(slack_name)
         else:
-            responded_user_ids = [user.slack_id for user in SocialProfile.objects.all() if user.slack_id]
-            non_responded_user_ids = set(user_id__slack_name).difference(responded_user_ids)
+            user_ids = set(user_id__slack_name)
 
         # notify developer of send status
         if not_found_users:
             print(f'WARNING: These users not found: {", ".join(not_found_users)}\n')
         print(
             'Preparing to send messages to: '
-            f'{", ".join([user_id__slack_name[uid] for uid in non_responded_user_ids])}.'
+            f'{", ".join([user_id__slack_name[uid] for uid in user_ids])}.'
         )
         print()
 
@@ -74,7 +76,7 @@ class Command(BaseCommand):
         # send
         print('Sending:')
 
-        for user_id in non_responded_user_ids:
+        for user_id in user_ids:
             slack_client.chat_postMessage(channel=user_id, blocks=greeting_blocks(user_id))
             print(user_id)
             time.sleep(1.0)  # attempting to avoid rate limiting

--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -119,6 +119,67 @@ def onboarding_blocks(profile=None):
     return template
 
 
+def after_survey_blocks():
+    admins = settings.PENNY_ADMIN_USERS
+    blocks = [
+        {
+            'type': 'section',
+            'text': {
+                'type': 'plain_text',
+                'text': 'Thanks for filling out our interests survey!',
+                'emoji': True
+            }
+        },
+        {
+            'type': 'divider'
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': 'Want a tour of our tools? Check out this quick tutorial:'
+            },
+            'accessory': {
+                'type': 'button',
+                'text': {
+                    'type': 'plain_text',
+                    'text': 'Watch Video',
+                    'emoji': True
+                },
+                'style': 'primary',
+                'url': 'https://www.youtube.com/watch?v=4ZUkckifPqE',
+                'action_id': 'watch_platform_tutorial'
+            }
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': 'Want to review some recent Penny Chats?'
+            },
+            'accessory': {
+                'type': 'button',
+                'text': {
+                    'type': 'plain_text',
+                    'text': 'Go to Penny Chats',
+                    'emoji': True
+                },
+                'style': 'primary',
+                'url': 'https://pennyuniversity.org/chats',
+                'action_id': 'go_to_penny_chats'
+            }
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'Any questions? Feel free to reach out to <{admins[0]}> or <{admins[1]}>.'
+            }
+        }
+    ]
+    return blocks
+
+
 class GreetingBotModule(BotModule):
     processors = [
         'welcome_user',
@@ -170,3 +231,5 @@ class GreetingBotModule(BotModule):
 
         self.slack.chat_postMessage(channel=GREETING_CHANNEL, text=message)
         notify_admins(self.slack, f'User <@{slack_id}> just filled out the survey.')
+
+        self.slack.chat_postMessage(channel=slack_id, blocks=after_survey_blocks())

--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -76,6 +76,9 @@ def onboarding_blocks(profile=None):
             {
                 'name': 'topics_to_learn',
                 'type': 'input',
+                "element": {
+                    "type": "plain_text_input"
+                },
                 'label': 'What do you want to learn about?',
                 'hint': 'Provide a comma separated list of subjects you would be interested in learning.',
                 'optional': 'true',
@@ -84,6 +87,9 @@ def onboarding_blocks(profile=None):
             {
                 'name': 'topics_to_share',
                 'type': 'input',
+                "element": {
+                    "type": "plain_text_input"
+                },
                 'label': 'What are you able to share with others?',
                 'hint': 'Provide a comma separated list of subjects you know a thing or two about.',
                 'optional': 'true',

--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -23,52 +23,15 @@ def greeting_blocks(user_id):
             'type': 'section',
             'text': {
                 'type': 'mrkdwn',
-                'text': f'*Welcome to Penny University, <@{user_id}>*',
+                'text': f'*Hey, <@{user_id}>*!',
             }
         },
         {
             'type': 'section',
             'text': {
                 'type': 'mrkdwn',
-                'text': (
-                    'Penny University is a self-organizing, peer-to-peer learning community. In Penny U there are no '
-                    '"mentors" or "mentees" but rather peers that enjoy learning together, socially. '
-                )
-            }
-        },
-        {
-            'type': 'section',
-            'text': {
-                'type': 'mrkdwn',
-                'text': (
-                    '• If you have something you can teach, then let it be known. \n • If you have something you want '
-                    'to learn, then reach out to the community or to an individual and ask for help - buy them a coffee'
-                    ' or lunch, or jump on a Google Hangout. (This is called a _Penny Chat_.) \n • And when your Penny '
-                    'Chat is complete, show your appreciation by posting a Penny Chat review in our '
-                    '<http://pennyuniversity.org|forum>. Teach us a little of what you have learned.'
-                ),
-            }
-        },
-        {
-            'type': 'section',
-            'text': {
-                'type': 'mrkdwn',
-                'text': (
-                    'Penny U is on the move. If all goes well then I, your trusty robot sidekick, will gain super '
-                    'powers in the coming months. I will help you find the answers you\'re looking for. I will also '
-                    'replace our lowly <http://pennyuniversity.org|Google Groups home page> with something a little '
-                    'more... appealing. If you want to help use out then let <@U42HCBFEF> and <@UES202FV5> know.'
-                ),
-            }
-        },
-        {
-            'type': 'section',
-            'text': {
-                'type': 'mrkdwn',
-                'text': (
-                    'Next steps - let us know a little more about yourself. (_Note: survey response will be publicly '
-                    'viewable._)'
-                )
+                'text': 'Penny University connects people with similar interests in order for them to learn together. '
+                        'Add your interests so we can do the same for you.',
             }
         },
         {
@@ -78,7 +41,7 @@ def greeting_blocks(user_id):
                     'type': 'button',
                     'text': {
                         'type': 'plain_text',
-                        'text': 'What would you like to learn?',
+                        'text': 'Add My Interests',
                     },
                     'action_id': 'open_interests_dialog'
                 }
@@ -105,7 +68,7 @@ def welcome_room_blocks(user_id):
 def onboarding_blocks(profile=None):
     template = {
         'callback_id': 'interests',
-        'title': 'Let\'s get to know you',
+        'title': 'Help us get to know you',
         'submit_label': 'Submit',
         'notify_on_cancel': True,
         'state': 'arbitrary data',
@@ -113,7 +76,7 @@ def onboarding_blocks(profile=None):
             {
                 'name': 'topics_to_learn',
                 'type': 'textarea',
-                'label': 'What do you want to learn?',
+                'label': 'What do you want to learn about?',
                 'hint': 'Provide a comma separated list of subjects you would be interested in learning.',
                 'optional': 'true',
                 'value': profile.topics_to_learn if profile else ''
@@ -121,27 +84,11 @@ def onboarding_blocks(profile=None):
             {
                 'name': 'topics_to_share',
                 'type': 'textarea',
-                'label': 'What do you able to share with others?',
-                'hint': 'Provide a comma separated list of subjects you would be interested in sharing.',
+                'label': 'What are you able to share with others?',
+                'hint': 'Provide a comma separated list of subjects you know a thing or two about.',
                 'optional': 'true',
                 'value': profile.topics_to_share if profile else ''
-            },
-            {
-                'name': 'metro_name',
-                'type': 'text',
-                'label': 'Where are you from?',
-                'hint': 'City and state (or country if not the U.S.).',
-                'optional': 'true',
-                'value': profile.metro_name if profile else ''
-            },
-            {
-                'name': 'how_you_learned_about_pennyu',
-                'type': 'text',
-                'label': 'How did you learn about Penny University?',
-                'hint': 'Who told you? Where did you hear about us?',
-                'optional': 'true',
-                'value': profile.how_you_learned_about_pennyu if profile else ''
-            },
+            }
         ]
     }
     return template

--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -75,7 +75,7 @@ def onboarding_blocks(profile=None):
         'elements': [
             {
                 'name': 'topics_to_learn',
-                'type': 'textarea',
+                'type': 'plain_text_input',
                 'label': 'What do you want to learn about?',
                 'hint': 'Provide a comma separated list of subjects you would be interested in learning.',
                 'optional': 'true',
@@ -83,7 +83,7 @@ def onboarding_blocks(profile=None):
             },
             {
                 'name': 'topics_to_share',
-                'type': 'textarea',
+                'type': 'plain_text_input',
                 'label': 'What are you able to share with others?',
                 'hint': 'Provide a comma separated list of subjects you know a thing or two about.',
                 'optional': 'true',

--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -75,7 +75,7 @@ def onboarding_blocks(profile=None):
         'elements': [
             {
                 'name': 'topics_to_learn',
-                'type': 'plain_text_input',
+                'type': 'input',
                 'label': 'What do you want to learn about?',
                 'hint': 'Provide a comma separated list of subjects you would be interested in learning.',
                 'optional': 'true',
@@ -83,7 +83,7 @@ def onboarding_blocks(profile=None):
             },
             {
                 'name': 'topics_to_share',
-                'type': 'plain_text_input',
+                'type': 'input',
                 'label': 'What are you able to share with others?',
                 'hint': 'Provide a comma separated list of subjects you know a thing or two about.',
                 'optional': 'true',

--- a/bot/tests/test_utils.py
+++ b/bot/tests/test_utils.py
@@ -5,11 +5,12 @@ def test_channel_lookup(mocker):
     fake_slack_client = mocker.Mock()
     resp = mocker.Mock()
     resp.data = {'channels': [{'name': 'general', 'id': 'C123456'}]}
-    fake_slack_client.channels_list.return_value = resp
+    fake_slack_client.conversations_list.return_value = resp
 
     with mocker.patch('bot.utils.get_slack_client', return_value=fake_slack_client):
         chan_id_1 = channel_lookup('general')
         chan_id_2 = channel_lookup('general')
 
     assert chan_id_1 == chan_id_2 == 'C123456'
-    assert fake_slack_client.channels_list.call_count == 1, 'we must cache the channels_list call b/c it is expensive'
+    assert fake_slack_client.conversations_list.call_count == 1, \
+        'we must cache the channels_list call b/c it is expensive'

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -12,7 +12,7 @@ def channel_lookup(name):
     global _CHANNEL_NAME__ID
     if _CHANNEL_NAME__ID is None:
         slack_client = get_slack_client()
-        resp = slack_client.channels_list()
+        resp = slack_client.conversations_list()
         _CHANNEL_NAME__ID = {chan['name']: chan['id'] for chan in resp.data['channels']}
     return _CHANNEL_NAME__ID.get(name)
 


### PR DESCRIPTION
# Description
Updates the interest survey. The interest survey has been shortened, and uses the modal API instead of the outdated dialog API. Closes #333 

## Details
The message for users to add their interests looks like this:
<img width="843" alt="greeting" src="https://user-images.githubusercontent.com/31971995/90966232-c2579080-e495-11ea-858f-0e165b364cb9.png">

The new form has been simplified:
<img width="535" alt="Form" src="https://user-images.githubusercontent.com/31971995/90966233-c388bd80-e495-11ea-8bad-a0822d0744e9.png">

The form still sends a message to the #general channel to let people know about this user's interests.
<img width="466" alt="Channel message" src="https://user-images.githubusercontent.com/31971995/90966235-c5eb1780-e495-11ea-9a65-9d3d16821c3c.png">