### PR TITLE
Don't remove previous edit panel

### DIFF
--- a/bot/processors/pennychat.py
+++ b/bot/processors/pennychat.py
@@ -342,11 +342,6 @@ class PennyChatBotModule(BotModule):
         penny_chat_invitation.view = response.data['view']['id']
         penny_chat_invitation.save()
 
-        if event['actions'][0]['block_id'] == 'organizer_edit_after_share_button':
-            return
-        else:
-            requests.post(event['response_url'], json={'delete_original': True})
-
     @is_block_interaction_event
     @has_action_id([PENNY_CHAT_CAN_ATTEND, PENNY_CHAT_CAN_NOT_ATTEND])
     def attendance_selection(self, event):

--- a/pennychat/tests/api/test_penny_chat.py
+++ b/pennychat/tests/api/test_penny_chat.py
@@ -23,6 +23,7 @@ def test_penny_chat_list(test_chats_1):
     assert response.data['results'][0]['participants'][0]['role'] == 'Organizer'
     assert response.data['results'][0]['participants'][0]['user']['id'] == most_recent_chat.get_organizer().id
     assert chats[0]['title'] == most_recent_chat.title
+    assert chats[0]['follow_ups_count'] == 2
 
 
 @pytest.mark.django_db
@@ -46,6 +47,9 @@ def test_penny_chat__upcoming_or_popular(test_chats_2):
     assert len(titles) == 2
     assert 'future_chat' in titles
     assert 'old_chat_with_followups' in titles
+    chats = response.data['results']
+    assert chats[0]['follow_ups_count'] == 0
+    assert chats[1]['follow_ups_count'] == 2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# Description
Closes #326. The previous edit details message will not disappear when edit details is clicked, so when it is closed it will still be there.