### PR TITLE
Fixed greeting submit fails if user only fills in one of the fields.

### DIFF
--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -211,8 +211,8 @@ class GreetingBotModule(BotModule):
     def submit_interests(self, event):
         slack_id = event['user']['id']
         user_data = self.slack.users_info(user=slack_id).data['user']
-        topics_to_learn = event['view']['state']['values']['topics_to_learn']['topics_to_learn']['value']
-        topics_to_share = event['view']['state']['values']['topics_to_share']['topics_to_share']['value']
+        topics_to_learn = event['view']['state']['values']['topics_to_learn']['topics_to_learn'].get('value', '')
+        topics_to_share = event['view']['state']['values']['topics_to_share']['topics_to_share'].get('value', '')
         kwargs = dict(
             email=user_data['profile']['email'],
             slack_team_id=settings.SLACK_TEAM_ID,

--- a/bot/tests/processors/test_greeting.py
+++ b/bot/tests/processors/test_greeting.py
@@ -137,7 +137,9 @@ def test_submit_interests(mocker):
                     },
                     'topics_to_share': {
                         'topics_to_share': {
-                            'value': ''  # user omitted answer
+                            # user omitted answer
+                            # in this case the value key is omitted
+                            # see https://github.com/penny-university/penny_university/issues/355
                         }
                     }
                 }


### PR DESCRIPTION
# what
Altered test to replicate slack event content, and then fixed the handler.

# why
If users didn't fill out both answers the the code would error

# related
closes https://github.com/penny-university/penny_university/issues/355

