### PR TITLE
Updated greeting bot to use `member_joined_channel` event type.

### DIFF
--- a/bot/processors/greeting.py
+++ b/bot/processors/greeting.py
@@ -165,7 +165,7 @@ def after_survey_blocks():
                     'emoji': True
                 },
                 'style': 'primary',
-                'url': 'https://pennyuniversity.org/chats',
+                'url': 'https://www.pennyuniversity.org/chats/',
                 'action_id': 'go_to_penny_chats'
             }
         },
@@ -191,7 +191,7 @@ class GreetingBotModule(BotModule):
         self.slack = slack
 
     @in_room(GREETING_CHANNEL)
-    @has_event_type('message.channel_join')
+    @has_event_type('member_joined_channel')
     def welcome_user(self, event):
         self.slack.chat_postMessage(channel=event['user'], blocks=greeting_blocks(event['user']))
         self.slack.chat_postMessage(channel=channel_lookup(WELCOME_ROOM_CHANNEL),

--- a/bot/tests/processors/test_greeting.py
+++ b/bot/tests/processors/test_greeting.py
@@ -10,8 +10,7 @@ def test_greeting(mocker):
     GreetingBotModule.GREETING_MESSAGE = 'welcome'
     event = {
         'user': 'U42HCBFEF',
-        'type': 'message',
-        'subtype': 'channel_join',
+        'type': 'member_joined_channel',
         'ts': '1557281569.001300',
         'text': '<@U42HCBFEF> has joined the channel',
         'channel': 'GENERAL',

--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -76,15 +76,34 @@ instead.
 * Create a new app (https://api.slack.com/apps ... this URL comes up a lot) call it "dev_penny"
 * In the "OAuth & Permissions" tab set up auth scopes:
     * Bot Token Scopes:
+        * app_mentions:read
+        * channels:history
+        * channels:join
+        * channels:manage
         * channels:read
         * chat:write
+        * chat:write.customize
+        * chat:write.public
         * commands
+        * groups:history
+        * groups:read
+        * groups:write
+        * im:history
+        * im:read
+        * im:write
+        * incoming-webhook
+        * mpim:history
+        * mpim:read
+        * mpim:write
+        * team:read
         * users:read
         * users:read.email
     * User Token Scopes:
         * channel:history
-        * chat:write
-    * Install the bot in your App. (Note that if you have problems with auth scopes, you'll likely need to reinstall.)
+        * channels:read
+        * groups:read
+* Under "Event Subscriptions">"Subscribe to events on behalf of users" add event names `member_joined_channel` and `message.channels` 
+* Install the bot in your App. (Note that if you have problems with auth scopes, you'll likely need to reinstall.)
 * Stick the "Bot User OAuth Access Token" into your Heroku config as the `SLACK_API_KEY`
 * Set up slack callback hook URLs to point to Heroku QA
     * Subscribe to messages in public channels:


### PR DESCRIPTION
# what
* Upgraded from `message.channel_join` event type to `member_joined_channel`. 
* Updated docs.
* Fixed a broken link.

# why
Apparently [`member_joined_channel` is the new and improved way of detecting that people have joined a channel](https://api.slack.com/changelog/2017-05-rethinking-channel-entrance-and-exit-events-and-messages). This might be why I can't get `message.joined_channel` in my QA slack - maybe it's deprecated.

# related
closes https://github.com/penny-university/penny_university/issues/357