### PR TITLE
added review_match_requests command

### DIFF
--- a/matchmaking/management/commands/review_match_requests.py
+++ b/matchmaking/management/commands/review_match_requests.py
@@ -1,0 +1,53 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from matchmaking.models import MatchRequest
+
+
+class Command(BaseCommand):
+    help = (
+        'Pretty print a list of people recently signed up for a discussion match.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--since_days_ago',
+            dest='since_days_ago',
+            type=int,
+            default=7,
+            help='get matches since this many days ago',
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        print(get_recent_matches(options['since_days_ago']))
+
+
+def get_recent_matches(since_days_ago):
+    match_requests = MatchRequest.objects.filter(date__gte=timezone.now() - timedelta(days=since_days_ago))\
+        .select_related('topic_channel', 'profile')
+
+    topic_channel_to_profile = {}
+    profile_to_topic_channel = {}
+    for match in match_requests:
+        topic_channel_to_profile.setdefault(match.topic_channel, []).append(match.profile)
+        profile_to_topic_channel.setdefault(match.profile, []).append(match.topic_channel)
+
+    output_str = []
+    output_str.append("PROFILE TO TOPICS")
+    for profile, topic_channels in profile_to_topic_channel.items():
+        output_str.append(f'{profile.email} ({profile.real_name}) requested a match for:')
+        for topic_channel in topic_channels:
+            output_str.append(f'\ttopic {topic_channel.name} in channel {topic_channel.channel_id}')
+        output_str.append('\n')
+
+    output_str.append("\n\nTOPIC TO PROFILES")
+    for topic_channel, profiles in topic_channel_to_profile.items():
+        output_str.append(f'Channel {topic_channel.channel_id} with topic {topic_channel.name} has interested people:')
+        for profile in profiles:
+            output_str.append(f'\ttopic {profile.email} ({profile.real_name})')
+        output_str.append('\n')
+
+    return '\n'.join(output_str)

--- a/matchmaking/tests.py
+++ b/matchmaking/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/matchmaking/tests/test_review_match_requests.py
+++ b/matchmaking/tests/test_review_match_requests.py
@@ -1,0 +1,78 @@
+from datetime import timedelta
+
+import pytest
+import pytz
+from django.utils import timezone
+
+from common.tests.fakes import SocialProfileFactory
+from freezegun import freeze_time
+from matchmaking.management.commands.review_match_requests import get_recent_matches
+from matchmaking.models import TopicChannel, MatchRequest
+
+UTC = pytz.utc
+
+
+@pytest.mark.django_db
+def test_review_match_requests():
+    profile1 = SocialProfileFactory()
+    profile2 = SocialProfileFactory()
+    profile3 = SocialProfileFactory()
+
+    chan1 = TopicChannel.objects.create(
+        channel_id='one',
+        slack_team_id='sl123',
+        name='uno',
+    )
+    chan2 = TopicChannel.objects.create(
+        channel_id='two',
+        slack_team_id='sl123',
+        name='dos',
+    )
+
+    # recent
+    with freeze_time(timezone.now() - timedelta(days=3), tz_offset=0):
+        MatchRequest.objects.create(
+            topic_channel=chan1,
+            profile=profile1,
+        )
+        MatchRequest.objects.create(
+            topic_channel=chan2,
+            profile=profile1,
+        )
+        MatchRequest.objects.create(
+            topic_channel=chan1,
+            profile=profile2,
+        )
+
+    # old - this one better not show up
+    with freeze_time(timezone.now() - timedelta(days=30), tz_offset=0):
+        MatchRequest.objects.create(
+            topic_channel=chan1,
+            profile=profile3,
+        )
+
+    actual = get_recent_matches(since_days_ago=7)
+    expected = f"""PROFILE TO TOPICS
+{profile1.email} ({profile1.real_name}) requested a match for:
+	topic {chan1.name} in channel {chan1.channel_id}
+	topic {chan2.name} in channel {chan2.channel_id}
+
+
+{profile2.email} ({profile2.real_name}) requested a match for:
+	topic {chan1.name} in channel {chan1.channel_id}
+
+
+
+
+TOPIC TO PROFILES
+Channel {chan1.channel_id} with topic {chan1.name} has interested people:
+	topic {profile1.email} ({profile1.real_name})
+	topic {profile2.email} ({profile2.real_name})
+
+
+Channel two with topic dos has interested people:
+	topic {profile1.email} ({profile1.real_name})
+
+"""  # noqa
+
+    assert actual == expected  # noqa


### PR DESCRIPTION
# what
Created `review_match_requests` which prints the users that requests to be matched and the topics that they would like to be matched with.

# why
This will help us figure out how to pair people together for our 🍩 🔪 feature