### PR TITLE
make get_organizer -> get_organizers (plural)

### DIFF
--- a/bot/tests/processors/test_pennychat.py
+++ b/bot/tests/processors/test_pennychat.py
@@ -189,16 +189,14 @@ def test_PennyChatBotModule_share(mocker):
     )
 
     # The Actual Test (premature close)
-    with mocker.patch('pennychat.models.get_or_create_social_profile_from_slack_id', side_effect=id_mock), \
-         post_organizer_edit_after_share_blocks:
+    with mocker.patch('pennychat.models.get_or_create_social_profile_from_slack_id', side_effect=id_mock), post_organizer_edit_after_share_blocks:  # noqa
         PennyChatBotModule(mocker.Mock()).submit_details_and_share(event)
 
     assert share_penny_chat_invitation.call_count == 0
 
     # The Actual Test (actual submission)
     event['type'] = penny_chat_constants.VIEW_SUBMISSION
-    with mocker.patch('pennychat.models.get_or_create_social_profile_from_slack_id', side_effect=id_mock), \
-         post_organizer_edit_after_share_blocks:
+    with mocker.patch('pennychat.models.get_or_create_social_profile_from_slack_id', side_effect=id_mock), post_organizer_edit_after_share_blocks:  # noqa
         PennyChatBotModule(mocker.Mock()).submit_details_and_share(event)
 
     assert share_penny_chat_invitation.call_args == call(penny_chat_invitation.id)
@@ -211,7 +209,7 @@ def test_PennyChatBotModule_share(mocker):
     assert penny_chat.description == 'new_description'
     assert penny_chat.date == penny_chat_invitation.date
     assert penny_chat.status == PennyChat.SHARED
-    assert penny_chat_invitation.get_organizer() == organizer.user
+    assert organizer.user in penny_chat_invitation.get_organizers()
     assert penny_chat_invitation.status == PennyChatSlackInvitation.SHARED
 
 

--- a/pennychat/models.py
+++ b/pennychat/models.py
@@ -55,8 +55,8 @@ class PennyChat(models.Model):
             defaults=dict(role=role),
         )
 
-    def get_organizer(self):
-        return User.objects.get(
+    def get_organizers(self):
+        return User.objects.filter(
             user_chats__penny_chat=self,
             user_chats__role=Participant.ORGANIZER,
         )

--- a/pennychat/tests/api/test_follow_up.py
+++ b/pennychat/tests/api/test_follow_up.py
@@ -23,7 +23,7 @@ def test_follow_up_list(test_chats_1):
 @pytest.mark.django_db
 def test_create_follow_up(test_chats_1):
     penny_chat = test_chats_1[0]
-    user = penny_chat.get_organizer()
+    user = penny_chat.get_organizers()[0]
     token = Token.objects.create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
@@ -55,7 +55,7 @@ def test_create_follow_up_unauthorized(test_chats_1):
 @pytest.mark.django_db
 def test_update_follow_up(test_chats_1):
     first_penny_chat = test_chats_1[0]
-    user = first_penny_chat.get_organizer()
+    user = first_penny_chat.get_organizers()[0]
     token = Token.objects.create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)

--- a/pennychat/tests/api/test_penny_chat.py
+++ b/pennychat/tests/api/test_penny_chat.py
@@ -89,7 +89,7 @@ def test_penny_chat_list(test_chats_1):
     # first chat should be most recent chat
     assert 'participants' in response.data['results'][0]
     assert response.data['results'][0]['participants'][0]['role'] == 'Organizer'
-    assert response.data['results'][0]['participants'][0]['user']['id'] == most_recent_chat.get_organizer().id
+    assert response.data['results'][0]['participants'][0]['user']['id'] == most_recent_chat.get_organizers()[0].id
     assert chats[0]['title'] == most_recent_chat.title
     assert chats[0]['follow_ups_count'] == 2
 
@@ -156,13 +156,13 @@ def test_penny_chat_detail(test_chats_1):
     assert response.status_code == 200
     assert 'participants' in response.data
     assert response.data['participants'][0]['role'] == 'Organizer'
-    assert response.data['participants'][0]['user']['id'] == penny_chat.get_organizer().id
+    assert response.data['participants'][0]['user']['id'] == penny_chat.get_organizers()[0].id
     assert response.data['title'] == penny_chat.title
 
 
 @pytest.mark.django_db
 def test_create_penny_chat(test_chats_1):
-    user = test_chats_1[0].get_organizer()
+    user = test_chats_1[0].get_organizers()[0]
     token = Token.objects.create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
@@ -181,7 +181,7 @@ def test_create_penny_chat(test_chats_1):
 
 @pytest.mark.django_db
 def test_create_penny_chat_without_date(test_chats_1):
-    user = test_chats_1[0].get_organizer()
+    user = test_chats_1[0].get_organizers()[0]
     token = Token.objects.create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
@@ -209,7 +209,7 @@ def test_create_penny_chat_unauthorized(test_chats_1):
 @pytest.mark.django_db
 def test_update_penny_chat(test_chats_1):
     penny_chat = test_chats_1[0]
-    user = penny_chat.get_organizer()
+    user = penny_chat.get_organizers()[0]
     token = Token.objects.create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
@@ -260,7 +260,7 @@ def test_update_penny_chat_wrong_user(test_chats_1):
 @pytest.mark.django_db
 def test_partial_update_penny_chat(test_chats_1):
     penny_chat = test_chats_1[0]
-    user = penny_chat.get_organizer()
+    user = penny_chat.get_organizers()[0]
     token = Token.objects.create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
@@ -304,7 +304,7 @@ def test_partial_update_penny_chat_wrong_user(test_chats_1):
 @pytest.mark.django_db
 def test_delete_penny_chat(test_chats_1):
     penny_chat = test_chats_1[0]
-    user = penny_chat.get_organizer()
+    user = penny_chat.get_organizers()[0]
     token = Token.objects.create(user=user)
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)

--- a/pennychat/views.py
+++ b/pennychat/views.py
@@ -70,13 +70,13 @@ class PennyChatViewSet(viewsets.ModelViewSet):
 
     @perform_is_authenticated
     def perform_update(self, serializer):
-        if self.get_object().get_organizer() != self.request.user:
+        if self.request.user not in self.get_object().get_organizers():
             raise PermissionDenied
         super().perform_update(serializer)
 
     @perform_is_authenticated
     def perform_destroy(self, instance):
-        if self.get_object().get_organizer() != self.request.user:
+        if self.request.user not in self.get_object().get_organizers():
             raise PermissionDenied
         super().perform_destroy(instance)
 


### PR DESCRIPTION
The new Penny Chat channel conversation flow introduced a situation where a single chat could have two owner participants. (If one person shared a chat and then a different person shared it.) This caused a sentry error https://sentry.io/organizations/penny-university/issues/1937265091/?project=5284085&referrer=slack It's a corner case, but rather than remove the first organizer I thought it was more reasonable to allow multiple people to organize a chat... I see this as something we'll need anyway at some point.

This fixes it so that rather than have a `penny_chat.get_organizer()` that returns a User object, there is a `penny_chat.get_organizers()` that returns a list (a QuerySet actually) of Users.