### PR TITLE
Create command to remind matches without Penny Chats to set one up

### DIFF
--- a/bot/processors/matchmaking.py
+++ b/bot/processors/matchmaking.py
@@ -15,34 +15,34 @@ REQUEST_MATCHES = 'request_matches'
 def request_match_blocks(channel_id):
     blocks = [
         {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"Hey folks! <#{channel_id}> has been set up as a topic channel. Every couple of weeks, "
-                        f"I (the Penny Bot) will set you up with other users to chat about <#{channel_id}>.",
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'Hey folks! <#{channel_id}> has been set up as a topic channel. Every couple of weeks, '
+                        f'I (the Penny Bot) will set you up with other users to chat about <#{channel_id}>.',
             }
         },
         {
-            "type": "section",
-            "text": {
-                "type": "plain_text",
-                "text": "If you're interested in having a virtual chat with another member of this channel next week, "
-                        "click the button below!",
-                "emoji": True,
+            'type': 'section',
+            'text': {
+                'type': 'plain_text',
+                'text': 'If you\'re interested in having a virtual chat with another member of this channel next week, '
+                        'click the button below!',
+                'emoji': True,
             }
         },
         {
-            "type": "actions",
-            "elements": [
+            'type': 'actions',
+            'elements': [
                 {
-                    "type": "button",
-                    "action_id": REQUEST_MATCHES,
-                    "text": {
-                        "type": "plain_text",
-                        "text": "I'm in! :handshake:",
-                        "emoji": True,
+                    'type': 'button',
+                    'action_id': REQUEST_MATCHES,
+                    'text': {
+                        'type': 'plain_text',
+                        'text': 'I\'m in! :handshake:',
+                        'emoji': True,
                     },
-                    "style": "primary",
+                    'style': 'primary',
                 }
             ]
         }
@@ -54,10 +54,10 @@ def request_match_blocks(channel_id):
 def confirm_match_request(channel_id):
     blocks = [
         {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"Awesome, we will match you with other users in <#{channel_id}> soon!",
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'Awesome, we will match you with other users in <#{channel_id}> soon!',
             }
         }
     ]
@@ -65,36 +65,41 @@ def confirm_match_request(channel_id):
     return blocks
 
 
-def create_match_blocks(topic_channel_id, conversation_id):
+def create_match_blocks(topic_channel_id, conversation_id, reminder=False):
+    if reminder:
+        message = f'You were matched for a conversation about <#{topic_channel_id}>, but it looks like you haven\'t ' \
+                  f'created a Penny Chat yet.'
+    else:
+        message = f'Yahoo, you\'ve been matched for a conversation about <#{topic_channel_id}>!'
     blocks = [
         {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"Yahoo, you've been matched for a conversation about <#{topic_channel_id}>!",
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': message,
             }
         },
         {
-            "type": "section",
-            "text": {
-                "type": "plain_text",
-                "text": "Work together to find a time to meet and chat. Once you do, "
-                        "click the button below to schedule a Penny Chat.",
+            'type': 'section',
+            'text': {
+                'type': 'plain_text',
+                'text': 'Work together to find a time to meet and chat. Once you do, '
+                        'click the button below to schedule a Penny Chat.',
             }
         },
         {
-            "type": "actions",
-            "elements": [
+            'type': 'actions',
+            'elements': [
                 {
-                    "type": "button",
-                    "action_id": PENNY_CHAT_SCHEDULE_MATCH,
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Schedule Chat :calendar:",
-                        "emoji": True,
+                    'type': 'button',
+                    'action_id': PENNY_CHAT_SCHEDULE_MATCH,
+                    'text': {
+                        'type': 'plain_text',
+                        'text': 'Schedule Chat :calendar:',
+                        'emoji': True,
                     },
-                    "value": conversation_id,
-                    "style": "primary",
+                    'value': conversation_id,
+                    'style': 'primary',
                 }
             ]
         }

--- a/bot/processors/matchmaking.py
+++ b/bot/processors/matchmaking.py
@@ -67,24 +67,20 @@ def confirm_match_request(channel_id):
 
 def create_match_blocks(topic_channel_id, conversation_id, reminder=False):
     if reminder:
-        message = f'You were matched for a conversation about <#{topic_channel_id}>, but it looks like you haven\'t ' \
-                  f'created a Penny Chat yet.'
+        message = f'''Hey! Were you all able to meet for the <#{topic_channel_id}> discussion?
+
+If not, there\'s still time. Just click the button below when you\'re ready to set up the Penny Chat.'''
     else:
-        message = f'Yahoo, you\'ve been matched for a conversation about <#{topic_channel_id}>!'
+        message = f'''Yahoo, you\'ve been matched for a conversation about <#{topic_channel_id}>!
+
+Work together to find a time to meet and chat. Once you do, click the button below to schedule a Penny Chat.'''
+
     blocks = [
         {
             'type': 'section',
             'text': {
                 'type': 'mrkdwn',
                 'text': message,
-            }
-        },
-        {
-            'type': 'section',
-            'text': {
-                'type': 'plain_text',
-                'text': 'Work together to find a time to meet and chat. Once you do, '
-                        'click the button below to schedule a Penny Chat.',
             }
         },
         {

--- a/matchmaking/management/commands/remind_matches.py
+++ b/matchmaking/management/commands/remind_matches.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+
+from common.utils import get_slack_client
+from matchmaking.models import Match
+from bot.processors.matchmaking import create_match_blocks
+
+
+class Command(BaseCommand):
+    help = """Remind matches without Penny Chats to set one up."""
+
+    def handle(self, *args, **options):
+        slack_client = get_slack_client()
+        matches_without_penny_chats = Match.objects.filter(penny_chat__isnull=True)
+        for match in matches_without_penny_chats:
+            blocks = create_match_blocks(match.topic_channel.channel_id, match.conversation_id, reminder=True)
+            slack_client.chat_postMessage(channel=match.conversation_id, blocks=blocks)

--- a/matchmaking/tests/test_make_matches.py
+++ b/matchmaking/tests/test_make_matches.py
@@ -32,15 +32,7 @@ def test_make_matches(mocker):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Yahoo, you've been matched for a conversation about <#one>!",
-            }
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "plain_text",
-                "text": "Work together to find a time to meet and chat. Once you do, "
-                        "click the button below to schedule a Penny Chat.",
+                "text": "Yahoo, you've been matched for a conversation about <#one>!\n\nWork together to find a time to meet and chat. Once you do, click the button below to schedule a Penny Chat.",  # noqa
             }
         },
         {


### PR DESCRIPTION
Chose speed and went for something dead simple here. Just use `./manage.py remind_matches` and send matches without Penny chats a message like this:

![Screen Shot 2020-10-14 at 5 37 29 PM](https://user-images.githubusercontent.com/31971995/96053281-db9d0d80-0e44-11eb-892e-ee48a89c1798.png)
 